### PR TITLE
fix(currency): reject Long.MIN_VALUE adjustment

### DIFF
--- a/src/main/java/ltdjms/discord/currency/domain/MemberCurrencyAccount.java
+++ b/src/main/java/ltdjms/discord/currency/domain/MemberCurrencyAccount.java
@@ -67,6 +67,9 @@ public record MemberCurrencyAccount(
    * @return true if the absolute value is within MAX_ADJUSTMENT_AMOUNT
    */
   public static boolean isValidAdjustmentAmount(long amount) {
+    if (amount == Long.MIN_VALUE) {
+      return false;
+    }
     return Math.abs(amount) <= MAX_ADJUSTMENT_AMOUNT;
   }
 }

--- a/src/test/java/ltdjms/discord/currency/contract/BalanceAdjustmentContractTest.java
+++ b/src/test/java/ltdjms/discord/currency/contract/BalanceAdjustmentContractTest.java
@@ -81,17 +81,15 @@ class BalanceAdjustmentContractTest {
   }
 
   @Test
-  @DisplayName("Account adjustment validation accepts all long values")
-  void accountAdjustmentValidationAcceptsAllLongValues() {
-    // Given - MAX_ADJUSTMENT_AMOUNT is now Long.MAX_VALUE
-    // All long values should be considered valid for adjustment amounts
-
-    // Then - validation should accept all values
+  @DisplayName("Account adjustment validation rejects Long.MIN_VALUE")
+  void accountAdjustmentValidationRejectsLongMinValue() {
+    // Then - validation should accept all values except Long.MIN_VALUE (abs overflow)
     assertThat(MemberCurrencyAccount.isValidAdjustmentAmount(1L)).isTrue();
     assertThat(MemberCurrencyAccount.isValidAdjustmentAmount(-1L)).isTrue();
     assertThat(MemberCurrencyAccount.isValidAdjustmentAmount(Long.MAX_VALUE)).isTrue();
     // Note: Long.MIN_VALUE + 1 is used instead of -Long.MAX_VALUE to avoid overflow
     assertThat(MemberCurrencyAccount.isValidAdjustmentAmount(Long.MIN_VALUE + 1)).isTrue();
+    assertThat(MemberCurrencyAccount.isValidAdjustmentAmount(Long.MIN_VALUE)).isFalse();
   }
 
   @Test


### PR DESCRIPTION
## Summary
- reject Long.MIN_VALUE in MemberCurrencyAccount adjustment validation
- update contract test to cover Long.MIN_VALUE edge case

## Testing
- not run (Spotless ran during commit)