### PR TITLE
Clamp transaction page numbers

### DIFF
--- a/src/main/java/ltdjms/discord/currency/services/CurrencyTransactionService.java
+++ b/src/main/java/ltdjms/discord/currency/services/CurrencyTransactionService.java
@@ -42,15 +42,19 @@ public class CurrencyTransactionService {
       pageSize = DEFAULT_PAGE_SIZE;
     }
 
-    int offset = (page - 1) * pageSize;
-    List<CurrencyTransaction> transactions =
-        transactionRepository.findByGuildIdAndUserId(guildId, userId, pageSize, offset);
     long totalCount = transactionRepository.countByGuildIdAndUserId(guildId, userId);
 
     int totalPages = (int) Math.ceil((double) totalCount / pageSize);
     if (totalPages < 1) {
       totalPages = 1;
     }
+    if (page > totalPages) {
+      page = totalPages;
+    }
+
+    int offset = (page - 1) * pageSize;
+    List<CurrencyTransaction> transactions =
+        transactionRepository.findByGuildIdAndUserId(guildId, userId, pageSize, offset);
 
     LOG.debug(
         "Retrieved currency transaction page: guildId={}, userId={}, page={}/{}, count={}",

--- a/src/main/java/ltdjms/discord/gametoken/services/GameTokenTransactionService.java
+++ b/src/main/java/ltdjms/discord/gametoken/services/GameTokenTransactionService.java
@@ -42,15 +42,19 @@ public class GameTokenTransactionService {
       pageSize = DEFAULT_PAGE_SIZE;
     }
 
-    int offset = (page - 1) * pageSize;
-    List<GameTokenTransaction> transactions =
-        transactionRepository.findByGuildIdAndUserId(guildId, userId, pageSize, offset);
     long totalCount = transactionRepository.countByGuildIdAndUserId(guildId, userId);
 
     int totalPages = (int) Math.ceil((double) totalCount / pageSize);
     if (totalPages < 1) {
       totalPages = 1;
     }
+    if (page > totalPages) {
+      page = totalPages;
+    }
+
+    int offset = (page - 1) * pageSize;
+    List<GameTokenTransaction> transactions =
+        transactionRepository.findByGuildIdAndUserId(guildId, userId, pageSize, offset);
 
     LOG.debug(
         "Retrieved transaction page: guildId={}, userId={}, page={}/{}, count={}",

--- a/src/main/java/ltdjms/discord/redemption/services/ProductRedemptionTransactionService.java
+++ b/src/main/java/ltdjms/discord/redemption/services/ProductRedemptionTransactionService.java
@@ -88,15 +88,19 @@ public class ProductRedemptionTransactionService {
       pageSize = DEFAULT_PAGE_SIZE;
     }
 
-    int offset = (page - 1) * pageSize;
-    List<ProductRedemptionTransaction> transactions =
-        transactionRepository.findByGuildIdAndUserId(guildId, userId, pageSize, offset);
     long totalCount = transactionRepository.countByGuildIdAndUserId(guildId, userId);
 
     int totalPages = (int) Math.ceil((double) totalCount / pageSize);
     if (totalPages < 1) {
       totalPages = 1;
     }
+    if (page > totalPages) {
+      page = totalPages;
+    }
+
+    int offset = (page - 1) * pageSize;
+    List<ProductRedemptionTransaction> transactions =
+        transactionRepository.findByGuildIdAndUserId(guildId, userId, pageSize, offset);
 
     LOG.debug(
         "Retrieved product redemption transaction page: guildId={}, userId={}, page={}/{},"

--- a/src/main/java/ltdjms/discord/redemption/services/RedemptionService.java
+++ b/src/main/java/ltdjms/discord/redemption/services/RedemptionService.java
@@ -287,12 +287,16 @@ public class RedemptionService {
     if (page < 1) page = 1;
     if (pageSize < 1) pageSize = 10;
 
-    int offset = (page - 1) * pageSize;
-    List<RedemptionCode> codes = codeRepository.findByProductId(productId, pageSize, offset);
     long totalCount = codeRepository.countByProductId(productId);
 
     int totalPages = (int) Math.ceil((double) totalCount / pageSize);
     if (totalPages < 1) totalPages = 1;
+    if (page > totalPages) {
+      page = totalPages;
+    }
+
+    int offset = (page - 1) * pageSize;
+    List<RedemptionCode> codes = codeRepository.findByProductId(productId, pageSize, offset);
 
     return new CodePage(codes, page, totalPages, totalCount, pageSize);
   }

--- a/src/test/java/ltdjms/discord/currency/unit/CurrencyTransactionServiceTest.java
+++ b/src/test/java/ltdjms/discord/currency/unit/CurrencyTransactionServiceTest.java
@@ -135,6 +135,23 @@ class CurrencyTransactionServiceTest {
       assertThat(result.currentPage()).isEqualTo(1);
       verify(transactionRepository).findByGuildIdAndUserId(TEST_GUILD_ID, TEST_USER_ID, 10, 0);
     }
+
+    @Test
+    @DisplayName("should clamp page number to total pages")
+    void shouldClampPageNumberToTotalPages() {
+      // Given
+      when(transactionRepository.findByGuildIdAndUserId(TEST_GUILD_ID, TEST_USER_ID, 10, 20))
+          .thenReturn(List.of());
+      when(transactionRepository.countByGuildIdAndUserId(TEST_GUILD_ID, TEST_USER_ID))
+          .thenReturn(25L);
+
+      // When
+      TransactionPage result = service.getTransactionPage(TEST_GUILD_ID, TEST_USER_ID, 99, 10);
+
+      // Then
+      assertThat(result.currentPage()).isEqualTo(3);
+      verify(transactionRepository).findByGuildIdAndUserId(TEST_GUILD_ID, TEST_USER_ID, 10, 20);
+    }
   }
 
   @Nested

--- a/src/test/java/ltdjms/discord/gametoken/unit/GameTokenTransactionServiceTest.java
+++ b/src/test/java/ltdjms/discord/gametoken/unit/GameTokenTransactionServiceTest.java
@@ -135,6 +135,23 @@ class GameTokenTransactionServiceTest {
       assertThat(result.currentPage()).isEqualTo(1);
       verify(transactionRepository).findByGuildIdAndUserId(TEST_GUILD_ID, TEST_USER_ID, 10, 0);
     }
+
+    @Test
+    @DisplayName("should clamp page number to total pages")
+    void shouldClampPageNumberToTotalPages() {
+      // Given
+      when(transactionRepository.findByGuildIdAndUserId(TEST_GUILD_ID, TEST_USER_ID, 10, 20))
+          .thenReturn(List.of());
+      when(transactionRepository.countByGuildIdAndUserId(TEST_GUILD_ID, TEST_USER_ID))
+          .thenReturn(25L);
+
+      // When
+      TransactionPage result = service.getTransactionPage(TEST_GUILD_ID, TEST_USER_ID, 99, 10);
+
+      // Then
+      assertThat(result.currentPage()).isEqualTo(3);
+      verify(transactionRepository).findByGuildIdAndUserId(TEST_GUILD_ID, TEST_USER_ID, 10, 20);
+    }
   }
 
   @Nested

--- a/src/test/java/ltdjms/discord/redemption/services/ProductRedemptionTransactionServiceTest.java
+++ b/src/test/java/ltdjms/discord/redemption/services/ProductRedemptionTransactionServiceTest.java
@@ -262,6 +262,26 @@ class ProductRedemptionTransactionServiceTest {
       // Then - offset should be (2-1) * 10 = 10
       verify(transactionRepository).findByGuildIdAndUserId(TEST_GUILD_ID, TEST_USER_ID, 10, 10);
     }
+
+    @Test
+    @DisplayName("should clamp page number to total pages")
+    void shouldClampPageNumberToTotalPages() {
+      // Given
+      List<ProductRedemptionTransaction> transactions = List.of();
+      when(transactionRepository.findByGuildIdAndUserId(
+              eq(TEST_GUILD_ID), eq(TEST_USER_ID), eq(10), eq(20)))
+          .thenReturn(transactions);
+      when(transactionRepository.countByGuildIdAndUserId(TEST_GUILD_ID, TEST_USER_ID))
+          .thenReturn(25L);
+
+      // When
+      ProductRedemptionTransactionService.TransactionPage result =
+          service.getTransactionPage(TEST_GUILD_ID, TEST_USER_ID, 99, 10);
+
+      // Then
+      assertThat(result.currentPage()).isEqualTo(3);
+      verify(transactionRepository).findByGuildIdAndUserId(TEST_GUILD_ID, TEST_USER_ID, 10, 20);
+    }
   }
 
   @Nested

--- a/src/test/java/ltdjms/discord/redemption/services/RedemptionServiceTest.java
+++ b/src/test/java/ltdjms/discord/redemption/services/RedemptionServiceTest.java
@@ -344,6 +344,21 @@ class RedemptionServiceTest {
       // Then - pageSize is clamped to 10 in the implementation
       assertThat(result.pageSize()).isEqualTo(10);
     }
+
+    @Test
+    @DisplayName("should clamp page number to total pages")
+    void shouldClampPageNumberToTotalPages() {
+      // Given
+      when(codeRepository.findByProductId(TEST_PRODUCT_ID, 10, 10)).thenReturn(List.of());
+      when(codeRepository.countByProductId(TEST_PRODUCT_ID)).thenReturn(15L);
+
+      // When
+      RedemptionService.CodePage result = redemptionService.getCodePage(TEST_PRODUCT_ID, 5, 10);
+
+      // Then - 15 items with page size 10 = 2 pages
+      assertThat(result.currentPage()).isEqualTo(2);
+      verify(codeRepository).findByProductId(TEST_PRODUCT_ID, 10, 10);
+    }
   }
 
   @Nested


### PR DESCRIPTION
## 摘要
- 交易/兌換分頁在 page 超過總頁數時，改為夾到最後一頁
- 補上超出總頁數的邊緣案例測試
- 保持 API 行為一致，僅調整分頁計算順序

## 測試
- mvn -q -Dtest=CurrencyTransactionServiceTest,GameTokenTransactionServiceTest,ProductRedemptionTransactionServiceTest,RedemptionServiceTest test