### PR TITLE
Handle null tool data in token estimator

### DIFF
--- a/src/main/java/ltdjms/discord/aiagent/services/TokenEstimator.java
+++ b/src/main/java/ltdjms/discord/aiagent/services/TokenEstimator.java
@@ -55,13 +55,16 @@ public final class TokenEstimator {
    */
   public int estimateTokens(ConversationMessage message) {
     // 內容
-    int contentTokens = (message.content().length() + CHARS_PER_TOKEN - 1) / CHARS_PER_TOKEN;
+    String content = message.content() == null ? "" : message.content();
+    int contentTokens = (content.length() + CHARS_PER_TOKEN - 1) / CHARS_PER_TOKEN;
 
     // 工具調用額外開銷
     if (message.role() == MessageRole.TOOL && message.toolCall().isPresent()) {
       var toolCall = message.toolCall().get();
-      int toolNameTokens = (toolCall.toolName().length() + CHARS_PER_TOKEN - 1) / CHARS_PER_TOKEN;
-      int resultTokens = (toolCall.result().length() + CHARS_PER_TOKEN - 1) / CHARS_PER_TOKEN;
+      String toolName = toolCall.toolName() == null ? "" : toolCall.toolName();
+      String result = toolCall.result() == null ? "" : toolCall.result();
+      int toolNameTokens = (toolName.length() + CHARS_PER_TOKEN - 1) / CHARS_PER_TOKEN;
+      int resultTokens = (result.length() + CHARS_PER_TOKEN - 1) / CHARS_PER_TOKEN;
       return contentTokens + toolNameTokens + resultTokens + 50; // +50 JSON 結構開銷
     }
 

--- a/src/test/java/ltdjms/discord/aiagent/services/AIAgentServicesTest.java
+++ b/src/test/java/ltdjms/discord/aiagent/services/AIAgentServicesTest.java
@@ -2,8 +2,10 @@ package ltdjms.discord.aiagent.services;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import org.junit.jupiter.api.DisplayName;
@@ -11,7 +13,10 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import ltdjms.discord.aiagent.domain.ChannelPermission;
+import ltdjms.discord.aiagent.domain.ConversationMessage;
+import ltdjms.discord.aiagent.domain.MessageRole;
 import ltdjms.discord.aiagent.domain.PermissionSetting;
+import ltdjms.discord.aiagent.domain.ToolCallInfo;
 import net.dv8tion.jda.api.Permission;
 
 /** Unit tests for aiagent.services package utility classes. */
@@ -210,6 +215,43 @@ class AIAgentServicesTest {
 
       // Then
       assertThat(result.permissionSet()).containsExactly(Permission.VIEW_CHANNEL);
+    }
+  }
+
+  @Nested
+  @DisplayName("TokenEstimator")
+  class TokenEstimatorTests {
+
+    @Test
+    @DisplayName("should handle null tool result when estimating tokens")
+    void shouldHandleNullToolResult() {
+      // Given
+      ToolCallInfo toolCall = new ToolCallInfo(null, Map.of(), true, null);
+      ConversationMessage message =
+          new ConversationMessage(
+              MessageRole.TOOL, "content", Instant.now(), Optional.of(toolCall));
+      TokenEstimator estimator = new TokenEstimator(4000);
+
+      // When
+      int tokens = estimator.estimateTokens(message);
+
+      // Then
+      assertThat(tokens).isEqualTo(52);
+    }
+
+    @Test
+    @DisplayName("should handle null content when estimating tokens")
+    void shouldHandleNullContent() {
+      // Given
+      ConversationMessage message =
+          new ConversationMessage(MessageRole.USER, null, Instant.now(), Optional.empty());
+      TokenEstimator estimator = new TokenEstimator(4000);
+
+      // When
+      int tokens = estimator.estimateTokens(message);
+
+      // Then
+      assertThat(tokens).isEqualTo(10);
     }
   }
 


### PR DESCRIPTION
## Summary
- guard against null message content/tool call fields in TokenEstimator
- add tests for null tool result and null content

## Testing
- mvn -q -Dtest=AIAgentServicesTest test