### PR TITLE
Limit shop purchase menu options to 25

### DIFF
--- a/src/main/java/ltdjms/discord/shop/services/ShopView.java
+++ b/src/main/java/ltdjms/discord/shop/services/ShopView.java
@@ -15,6 +15,7 @@ public class ShopView {
 
   private static final Color EMBED_COLOR = new Color(0x5865F2);
   private static final int PAGE_SIZE = 5;
+  private static final int MAX_PURCHASE_OPTIONS = 25;
   private static final String DIVIDER = "────────────────────────────────────";
 
   public static final String BUTTON_PREV_PAGE = "shop_prev_";
@@ -133,7 +134,9 @@ public class ShopView {
     StringSelectMenu.Builder menuBuilder =
         StringSelectMenu.create(SELECT_PURCHASE_PRODUCT).setPlaceholder("選擇要購買的商品");
 
-    for (Product product : productsForPurchase) {
+    int limit = Math.min(productsForPurchase.size(), MAX_PURCHASE_OPTIONS);
+    for (int i = 0; i < limit; i++) {
+      Product product = productsForPurchase.get(i);
       String label = product.name();
       String description = product.formatCurrencyPrice();
       menuBuilder.addOption(label, String.valueOf(product.id()), description);

--- a/src/test/java/ltdjms/discord/shop/services/ShopViewTest.java
+++ b/src/test/java/ltdjms/discord/shop/services/ShopViewTest.java
@@ -145,6 +145,22 @@ class ShopViewTest {
   }
 
   @Test
+  @DisplayName("buildPurchaseMenu 應該限制最多 25 個選項")
+  void buildPurchaseMenuShouldLimitOptions() {
+    List<Product> products =
+        java.util.stream.IntStream.range(0, 30)
+            .mapToObj(
+                i -> Product.createWithCurrencyPrice(TEST_GUILD_ID, "商品 " + i, null, 100L + i))
+            .toList();
+
+    var menu = ShopView.buildPurchaseMenu(products);
+
+    assertThat(menu.getOptions()).hasSize(25);
+    assertThat(menu.getOptions().get(0).getLabel()).isEqualTo("商品 0");
+    assertThat(menu.getOptions().get(24).getLabel()).isEqualTo("商品 24");
+  }
+
+  @Test
   @DisplayName("buildPurchaseConfirmEmbed 應該建立確認 Embed")
   void buildPurchaseConfirmEmbedShouldCreateConfirmationEmbed() {
     Product product = Product.createWithCurrencyPrice(TEST_GUILD_ID, "測試商品", null, 100L);


### PR DESCRIPTION
## Related Issues / Motivation
- Related: N/A
- Prevent Discord select menu overflow when many purchasable products exist.

## Engineering Decisions and Rationale
- Clamp purchase menu options to the Discord/JDA limit (25) at the view builder.
- Add a unit test to preserve ordering and enforce the cap.

## Test Results and Commands
- ✅ `mvn -q -Dtest=ShopViewTest test`

### Test Cases (for complex changes)
- Not applicable for this change.
