### PR TITLE
Escape JSON field names in tool responses

### DIFF
--- a/src/main/java/ltdjms/discord/aiagent/services/tools/ToolJsonResponses.java
+++ b/src/main/java/ltdjms/discord/aiagent/services/tools/ToolJsonResponses.java
@@ -103,7 +103,8 @@ public final class ToolJsonResponses {
       "%s": "%s"
     }
     """
-        .formatted(escapeJson(message), fieldName, escapeJson(String.valueOf(fieldValue)));
+        .formatted(
+            escapeJson(message), escapeJson(fieldName), escapeJson(String.valueOf(fieldValue)));
   }
 
   /**
@@ -132,9 +133,9 @@ public final class ToolJsonResponses {
     """
         .formatted(
             escapeJson(message),
-            field1Name,
+            escapeJson(field1Name),
             escapeJson(String.valueOf(field1Value)),
-            field2Name,
+            escapeJson(field2Name),
             escapeJson(String.valueOf(field2Value)));
   }
 

--- a/src/test/java/ltdjms/discord/aiagent/unit/services/tools/ToolJsonResponsesTest.java
+++ b/src/test/java/ltdjms/discord/aiagent/unit/services/tools/ToolJsonResponsesTest.java
@@ -1,0 +1,30 @@
+package ltdjms.discord.aiagent.unit.services.tools;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import ltdjms.discord.aiagent.services.tools.ToolJsonResponses;
+
+@DisplayName("ToolJsonResponses 邊緣案例")
+class ToolJsonResponsesTest {
+
+  @Test
+  @DisplayName("successWithField 應轉義欄位名稱中的特殊字元")
+  void shouldEscapeFieldNameInSuccessWithField() {
+    String result = ToolJsonResponses.successWithField("ok", "field\"name\n", "value");
+
+    assertThat(result).contains("\"field\\\"name\\n\"");
+  }
+
+  @Test
+  @DisplayName("successWithFields 應轉義多個欄位名稱中的特殊字元")
+  void shouldEscapeFieldNamesInSuccessWithFields() {
+    String result =
+        ToolJsonResponses.successWithFields("ok", "first\"name", 1, "second\nname", "value");
+
+    assertThat(result).contains("\"first\\\"name\"");
+    assertThat(result).contains("\"second\\nname\"");
+  }
+}


### PR DESCRIPTION
## Related Issues / Motivation
- Related: N/A
- ToolJsonResponses did not escape field names in success responses, which could generate invalid JSON when names contain quotes or newlines.

## Engineering Decisions and Rationale
- Escape field names using the existing escapeJson helper to keep behavior consistent with other response paths.
- Add focused unit tests covering special characters to prevent regressions.

## Test Results and Commands
- ✅ 
