### PR TITLE
Guard Discord thread history limits

### DIFF
--- a/src/main/java/ltdjms/discord/aiagent/services/DiscordThreadHistoryProvider.java
+++ b/src/main/java/ltdjms/discord/aiagent/services/DiscordThreadHistoryProvider.java
@@ -70,6 +70,11 @@ public final class DiscordThreadHistoryProvider {
    */
   public List<ChatMessage> getThreadHistory(
       long guildId, long threadId, long requesterUserId, long botUserId) {
+    if (maxMessages <= 0) {
+      LOG.warn("無法獲取 Thread 歷史：maxMessages <= 0 ({}), threadId={}", maxMessages, threadId);
+      return List.of();
+    }
+
     Guild guild = getJda().getGuildById(guildId);
     if (guild == null) {
       LOG.warn("找不到伺服器: guildId={}", guildId);
@@ -167,6 +172,9 @@ public final class DiscordThreadHistoryProvider {
    */
   private List<ChatMessage> trimByTokens(List<ChatMessage> messages) {
     int maxTokens = tokenEstimator.getMaxTokens();
+    if (maxTokens <= 0) {
+      return List.of();
+    }
     int currentTokens = 0;
     List<ChatMessage> result = new ArrayList<>();
 

--- a/src/test/java/ltdjms/discord/aiagent/unit/services/DiscordThreadHistoryProviderTest.java
+++ b/src/test/java/ltdjms/discord/aiagent/unit/services/DiscordThreadHistoryProviderTest.java
@@ -15,6 +15,7 @@ import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.UserMessage;
 import ltdjms.discord.aiagent.services.DiscordThreadHistoryProvider;
 import ltdjms.discord.aiagent.services.TokenEstimator;
+import ltdjms.discord.shared.di.JDAProvider;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageType;
 import net.dv8tion.jda.api.entities.User;
@@ -81,5 +82,34 @@ class DiscordThreadHistoryProviderTest {
     assertThat(((UserMessage) chatMessages.get(0)).singleText()).isEqualTo("使用者訊息");
     assertThat(chatMessages.get(1)).isInstanceOf(AiMessage.class);
     assertThat(((AiMessage) chatMessages.get(1)).text()).isEqualTo("機器人回覆");
+  }
+
+  @Test
+  @DisplayName("maxMessages 為非正數時應直接回傳空列表")
+  void shouldReturnEmptyWhenMaxMessagesNonPositive() {
+    JDAProvider.clear();
+    DiscordThreadHistoryProvider provider =
+        new DiscordThreadHistoryProvider(0, new TokenEstimator(4000));
+
+    List<ChatMessage> history = provider.getThreadHistory(1L, 2L, 3L, 4L);
+
+    assertThat(history).isEmpty();
+  }
+
+  @Test
+  @DisplayName("maxTokens 為非正數時應裁剪為空列表")
+  void shouldReturnEmptyWhenMaxTokensNonPositive() throws Exception {
+    DiscordThreadHistoryProvider provider =
+        new DiscordThreadHistoryProvider(10, new TokenEstimator(2000));
+    List<ChatMessage> messages = List.of(UserMessage.from("hello"), AiMessage.from("world"));
+
+    Method trimMethod =
+        DiscordThreadHistoryProvider.class.getDeclaredMethod("trimByTokens", List.class);
+    trimMethod.setAccessible(true);
+
+    @SuppressWarnings("unchecked")
+    List<ChatMessage> trimmed = (List<ChatMessage>) trimMethod.invoke(provider, messages);
+
+    assertThat(trimmed).isEmpty();
   }
 }


### PR DESCRIPTION
## Related Issues / Motivation
- Related: N/A
- Prevent invalid limits from triggering JDA access or over-budget history retention

## Engineering Decisions and Rationale
- Short-circuit when maxMessages <= 0 to avoid calling JDA without a valid limit
- Return empty history when maxTokens <= 0 to honor token budget constraints
- Add focused unit tests for both edge conditions

## Test Results and Commands
- ✅ mvn -q -Dtest=DiscordThreadHistoryProviderTest test
