### PR TITLE
Enforce admin guard on dispatch panel

### DIFF
--- a/src/main/java/ltdjms/discord/dispatch/commands/DispatchPanelCommandHandler.java
+++ b/src/main/java/ltdjms/discord/dispatch/commands/DispatchPanelCommandHandler.java
@@ -4,6 +4,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import ltdjms.discord.currency.bot.SlashCommandListener;
+import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 
 /** /dispatch-panel 指令：開啟派單面板。 */
@@ -13,12 +16,18 @@ public class DispatchPanelCommandHandler implements SlashCommandListener.Command
 
   @Override
   public void handle(SlashCommandInteractionEvent event) {
-    if (!event.isFromGuild() || event.getGuild() == null) {
+    Guild guild = event.getGuild();
+    if (!event.isFromGuild() || guild == null) {
       event.reply("此功能只能在伺服器中使用").setEphemeral(true).queue();
       return;
     }
 
-    long guildId = event.getGuild().getIdLong();
+    if (!isAdmin(event.getMember(), guild)) {
+      event.reply("你沒有權限使用派單面板").setEphemeral(true).queue();
+      return;
+    }
+
+    long guildId = guild.getIdLong();
     long adminUserId = event.getUser().getIdLong();
     LOG.debug("Opening dispatch panel: guildId={}, adminUserId={}", guildId, adminUserId);
 
@@ -27,5 +36,19 @@ public class DispatchPanelCommandHandler implements SlashCommandListener.Command
         .addComponents(DispatchPanelView.buildPanelComponents(false))
         .setEphemeral(true)
         .queue();
+  }
+
+  private boolean isAdmin(Member member, Guild guild) {
+    if (member == null || guild == null) {
+      return false;
+    }
+    if (member.hasPermission(Permission.ADMINISTRATOR)) {
+      return true;
+    }
+    try {
+      return guild.getOwnerIdLong() == member.getIdLong();
+    } catch (Exception ignored) {
+      return false;
+    }
   }
 }

--- a/src/main/java/ltdjms/discord/dispatch/commands/DispatchPanelInteractionHandler.java
+++ b/src/main/java/ltdjms/discord/dispatch/commands/DispatchPanelInteractionHandler.java
@@ -19,6 +19,7 @@ import ltdjms.discord.shared.DomainError;
 import ltdjms.discord.shared.Result;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.OnlineStatus;
+import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.MessageEmbed;
@@ -70,6 +71,11 @@ public class DispatchPanelInteractionHandler extends ListenerAdapter {
 
     if (!event.isFromGuild() || event.getGuild() == null) {
       event.reply("此功能只能在伺服器中使用").setEphemeral(true).queue();
+      return;
+    }
+
+    if (!isAdmin(event.getMember(), event.getGuild())) {
+      event.reply("你沒有權限使用派單面板").setEphemeral(true).queue();
       return;
     }
 
@@ -173,6 +179,11 @@ public class DispatchPanelInteractionHandler extends ListenerAdapter {
       return;
     }
 
+    if (!isAdmin(event.getMember(), event.getGuild())) {
+      event.reply("你沒有權限使用派單面板").setEphemeral(true).queue();
+      return;
+    }
+
     long guildId = event.getGuild().getIdLong();
     long adminUserId = event.getUser().getIdLong();
     String sessionKey = getSessionKey(adminUserId, guildId);
@@ -199,6 +210,11 @@ public class DispatchPanelInteractionHandler extends ListenerAdapter {
   private void handleHistory(ButtonInteractionEvent event) {
     if (!event.isFromGuild() || event.getGuild() == null) {
       event.reply("此功能只能在伺服器中使用").setEphemeral(true).queue();
+      return;
+    }
+
+    if (!isAdmin(event.getMember(), event.getGuild())) {
+      event.reply("你沒有權限使用派單面板").setEphemeral(true).queue();
       return;
     }
 
@@ -990,6 +1006,20 @@ public class DispatchPanelInteractionHandler extends ListenerAdapter {
 
   private String getSessionKey(long userId, long guildId) {
     return guildId + ":" + userId;
+  }
+
+  private boolean isAdmin(Member member, Guild guild) {
+    if (member == null || guild == null) {
+      return false;
+    }
+    if (member.hasPermission(Permission.ADMINISTRATOR)) {
+      return true;
+    }
+    try {
+      return guild.getOwnerIdLong() == member.getIdLong();
+    } catch (Exception ignored) {
+      return false;
+    }
   }
 
   private record AfterSalesNotifyResult(String message) {}

--- a/src/test/java/ltdjms/discord/dispatch/commands/DispatchPanelCommandHandlerTest.java
+++ b/src/test/java/ltdjms/discord/dispatch/commands/DispatchPanelCommandHandlerTest.java
@@ -1,0 +1,48 @@
+package ltdjms.discord.dispatch.commands;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
+
+class DispatchPanelCommandHandlerTest {
+
+  @Test
+  @DisplayName("非管理員不應該能開啟派單面板")
+  void nonAdminCannotOpenDispatchPanel() {
+    DispatchPanelCommandHandler handler = new DispatchPanelCommandHandler();
+
+    SlashCommandInteractionEvent event = mock(SlashCommandInteractionEvent.class);
+    Guild guild = mock(Guild.class);
+    Member member = mock(Member.class);
+    User user = mock(User.class);
+    ReplyCallbackAction replyAction = mock(ReplyCallbackAction.class);
+
+    when(event.isFromGuild()).thenReturn(true);
+    when(event.getGuild()).thenReturn(guild);
+    when(event.getMember()).thenReturn(member);
+    when(event.getUser()).thenReturn(user);
+    when(user.getIdLong()).thenReturn(123L);
+    when(member.hasPermission(Permission.ADMINISTRATOR)).thenReturn(false);
+    when(guild.getOwnerIdLong()).thenReturn(999L);
+    when(event.reply("你沒有權限使用派單面板")).thenReturn(replyAction);
+    when(replyAction.setEphemeral(true)).thenReturn(replyAction);
+
+    handler.handle(event);
+
+    verify(event).reply("你沒有權限使用派單面板");
+    verify(event, never()).replyEmbeds(any(MessageEmbed.class));
+  }
+}


### PR DESCRIPTION
## Related Issues / Motivation
- Related: N/A
- Prevent non-admin users from accessing dispatch panel actions if command permissions are misconfigured.

## Engineering Decisions and Rationale
- Add explicit admin/owner checks in DispatchPanelCommandHandler and DispatchPanelInteractionHandler to enforce server-side authorization.
- Match the existing admin policy (ADMINISTRATOR or guild owner) and return an ephemeral denial to avoid leaking panel content.

## Test Results and Commands
- ✅ `mvn -q -Dtest=DispatchPanelCommandHandlerTest test`

### Test Cases (for complex changes)
- Non-admin invokes `/dispatch-panel` -> denied with ephemeral reply (unit test).
