### PR TITLE
Skip empty paragraph chunks in accumulator

### DIFF
--- a/src/main/java/ltdjms/discord/aichat/services/MessageChunkAccumulator.java
+++ b/src/main/java/ltdjms/discord/aichat/services/MessageChunkAccumulator.java
@@ -32,9 +32,16 @@ public final class MessageChunkAccumulator {
     List<String> readyToSend = new ArrayList<>();
 
     // 1. 優先檢查段落分割（\n\n）
-    int paragraphEnd = findFirstParagraphBoundary();
-    if (paragraphEnd > 0 && paragraphEnd <= MAX_MESSAGE_LENGTH) {
+    while (true) {
+      int paragraphEnd = findFirstParagraphBoundary();
+      if (paragraphEnd <= 0 || paragraphEnd > MAX_MESSAGE_LENGTH) {
+        break;
+      }
       String chunk = buffer.substring(0, paragraphEnd);
+      if (chunk.trim().isEmpty()) {
+        buffer.delete(0, paragraphEnd);
+        continue;
+      }
       readyToSend.add(chunk);
       buffer.delete(0, paragraphEnd);
       return readyToSend;

--- a/src/test/java/ltdjms/discord/aichat/unit/MessageChunkAccumulatorTest.java
+++ b/src/test/java/ltdjms/discord/aichat/unit/MessageChunkAccumulatorTest.java
@@ -170,6 +170,21 @@ class MessageChunkAccumulatorTest {
   }
 
   @Test
+  void testAccumulate_leadingParagraphBoundary_shouldSkipEmptyChunk() {
+    MessageChunkAccumulator accumulator = new MessageChunkAccumulator();
+
+    List<String> chunks = accumulator.accumulate("\n\n");
+    assertThat(chunks).isEmpty();
+
+    chunks = accumulator.accumulate("第一段內容\n\n");
+    assertThat(chunks).hasSize(1);
+    assertThat(chunks.get(0)).isEqualTo("第一段內容\n\n");
+
+    String remaining = accumulator.drain();
+    assertThat(remaining).isEmpty();
+  }
+
+  @Test
   void testAccumulate_longParagraph_shouldForceSplit() {
     MessageChunkAccumulator accumulator = new MessageChunkAccumulator();
 


### PR DESCRIPTION
## Related Issues / Motivation
- Related: N/A
- Prevent empty Discord messages when the stream starts with a paragraph boundary

## Engineering Decisions and Rationale
- Skip paragraph boundaries that would emit whitespace-only chunks to avoid empty sends while keeping existing segmentation behavior
- Loop through consecutive paragraph boundaries so leading blank lines are discarded before evaluating content

## Test Results and Commands
- ✅ 

### Test Cases (for complex changes)
- Case 1: input starts with "\n\n" -> no chunk emitted until real content arrives