### PR TITLE
Reject past redemption code expiration

### DIFF
--- a/src/main/java/ltdjms/discord/redemption/services/RedemptionService.java
+++ b/src/main/java/ltdjms/discord/redemption/services/RedemptionService.java
@@ -105,6 +105,11 @@ public class RedemptionService {
       return Result.err(DomainError.invalidInput("單個兌換碼最多可兌換 1000 個商品"));
     }
 
+    // Validate expiration time
+    if (expiresAt != null && expiresAt.isBefore(Instant.now())) {
+      return Result.err(DomainError.invalidInput("過期時間必須在未來"));
+    }
+
     // Find product
     Optional<Product> productOpt = productRepository.findById(productId);
     if (productOpt.isEmpty()) {

--- a/src/test/java/ltdjms/discord/redemption/services/RedemptionServiceTest.java
+++ b/src/test/java/ltdjms/discord/redemption/services/RedemptionServiceTest.java
@@ -232,6 +232,19 @@ class RedemptionServiceTest {
       assertThat(result.isErr()).isTrue();
       assertThat(result.getError().message()).contains("1000");
     }
+
+    @Test
+    @DisplayName("should reject expiration time in the past")
+    void shouldRejectExpirationTimeInThePast() {
+      // When
+      Instant expiresAt = Instant.now().minus(1, ChronoUnit.SECONDS);
+      Result<List<RedemptionCode>, DomainError> result =
+          redemptionService.generateCodes(TEST_PRODUCT_ID, 1, expiresAt);
+
+      // Then
+      assertThat(result.isErr()).isTrue();
+      assertThat(result.getError().message()).contains("過期時間");
+    }
   }
 
   @Nested


### PR DESCRIPTION
## Related Issues / Motivation
- Related: N/A
- Why this change is needed: prevent generating redemption codes that are already expired

## Engineering Decisions and Rationale
- Validate expiresAt against current time in RedemptionService.generateCodes to reject past timestamps early
- Add a unit test to lock in the rejection behavior and avoid regressions

## Test Results and Commands
- ✅ 09:05:53,873 |-INFO in ch.qos.logback.classic.LoggerContext[default] - This is logback-classic version 1.5.12
09:05:53,874 |-INFO in ch.qos.logback.classic.util.ContextInitializer@4f402027 - No custom configurators were discovered as a service.
09:05:53,874 |-INFO in ch.qos.logback.classic.util.ContextInitializer@4f402027 - Trying to configure with ch.qos.logback.classic.joran.SerializedModelConfigurator
09:05:53,875 |-INFO in ch.qos.logback.classic.util.ContextInitializer@4f402027 - Constructed configurator of type class ch.qos.logback.classic.joran.SerializedModelConfigurator
09:05:53,875 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback-test.scmo]
09:05:53,875 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback.scmo]
09:05:53,877 |-INFO in ch.qos.logback.classic.util.ContextInitializer@4f402027 - ch.qos.logback.classic.joran.SerializedModelConfigurator.configure() call lasted 1 milliseconds. ExecutionStatus=INVOKE_NEXT_IF_ANY
09:05:53,877 |-INFO in ch.qos.logback.classic.util.ContextInitializer@4f402027 - Trying to configure with ch.qos.logback.classic.util.DefaultJoranConfigurator
09:05:53,877 |-INFO in ch.qos.logback.classic.util.ContextInitializer@4f402027 - Constructed configurator of type class ch.qos.logback.classic.util.DefaultJoranConfigurator
09:05:53,877 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback-test.xml]
09:05:53,878 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Found resource [logback.xml] at [file:/Users/tszkinlai/.codex/worktrees/1924/LTDJMS/target/classes/logback.xml]
09:05:53,951 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@22aee519 - value "logs" substituted for "${LOG_DIR:-logs}"
09:05:53,951 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@22aee519 - value "WARN" substituted for "${LOG_LEVEL:-WARN}"
09:05:53,951 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@22aee519 - value "INFO" substituted for "${APP_LOG_LEVEL:-INFO}"
09:05:53,952 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@22aee519 - value "20MB" substituted for "${LOG_MAX_FILE_SIZE:-20MB}"
09:05:53,952 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@22aee519 - value "30" substituted for "${LOG_MAX_HISTORY_DAYS:-30}"
09:05:53,952 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@22aee519 - value "3GB" substituted for "${LOG_TOTAL_SIZE_CAP:-3GB}"
09:05:53,953 |-INFO in ch.qos.logback.classic.model.processor.ConfigurationModelHandlerFull - Registering a new ReconfigureOnChangeTask ReconfigureOnChangeTask(born:1772067953953)
09:05:53,954 |-INFO in ch.qos.logback.classic.model.processor.ConfigurationModelHandlerFull - Will scan for changes in [ConfigurationWatchList(mainURL=file:/Users/tszkinlai/.codex/worktrees/1924/LTDJMS/target/classes/logback.xml, fileWatchList={/Users/tszkinlai/.codex/worktrees/1924/LTDJMS/target/classes/logback.xml}, urlWatchList=[})] 
09:05:53,954 |-INFO in ch.qos.logback.classic.model.processor.ConfigurationModelHandlerFull - Setting ReconfigureOnChangeTask scanning period to 30 seconds
09:05:53,956 |-INFO in ch.qos.logback.core.model.processor.AppenderModelHandler - Processing appender named [CONSOLE]
09:05:53,956 |-INFO in ch.qos.logback.core.model.processor.AppenderModelHandler - About to instantiate appender of type [ch.qos.logback.core.ConsoleAppender]
09:05:53,962 |-INFO in ch.qos.logback.core.model.processor.ImplicitModelHandler - Assuming default type [ch.qos.logback.classic.encoder.PatternLayoutEncoder] for [encoder] property
09:05:53,963 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@22aee519 - value "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n" substituted for "${LOG_PATTERN}"
09:05:53,984 |-WARN in ch.qos.logback.core.model.processor.AppenderModelHandler - Appender named [JSON_CONSOLE] not referenced. Skipping further processing.
09:05:53,984 |-INFO in ch.qos.logback.core.model.processor.AppenderModelHandler - Processing appender named [APP_FILE]
09:05:53,984 |-INFO in ch.qos.logback.core.model.processor.AppenderModelHandler - About to instantiate appender of type [ch.qos.logback.core.rolling.RollingFileAppender]
09:05:53,986 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@22aee519 - value "logs/app.log" substituted for "${LOG_DIR}/app.log"
09:05:53,989 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@22aee519 - value "logs/archive/app.%d{yyyy-MM-dd}.%i.log.gz" substituted for "${LOG_DIR}/archive/app.%d{yyyy-MM-dd}.%i.log.gz"
09:05:53,989 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@22aee519 - value "20MB" substituted for "${LOG_MAX_FILE_SIZE}"
09:05:53,989 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@22aee519 - value "30" substituted for "${LOG_MAX_HISTORY_DAYS}"
09:05:53,989 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@22aee519 - value "3GB" substituted for "${LOG_TOTAL_SIZE_CAP}"
09:05:53,989 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@2082627733 - setting totalSizeCap to 3 GB
09:05:53,992 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@2082627733 - Archive files will be limited to [20 MB] each.
09:05:53,993 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@2082627733 - Will use gz compression
09:05:53,994 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@2082627733 - Will use the pattern logs/archive/app.%d{yyyy-MM-dd}.%i.log for the active file
09:05:54,003 |-INFO in ch.qos.logback.core.rolling.SizeAndTimeBasedFileNamingAndTriggeringPolicy@7ea07516 - The date pattern is 'yyyy-MM-dd' from file name pattern 'logs/archive/app.%d{yyyy-MM-dd}.%i.log.gz'.
09:05:54,003 |-INFO in ch.qos.logback.core.rolling.SizeAndTimeBasedFileNamingAndTriggeringPolicy@7ea07516 - Roll-over at midnight.
09:05:54,007 |-INFO in ch.qos.logback.core.rolling.SizeAndTimeBasedFileNamingAndTriggeringPolicy@7ea07516 - Setting initial period to 2026-02-26T01:05:43.360Z
09:05:54,008 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@2082627733 - Cleaning on start up
09:05:54,009 |-INFO in c.q.l.core.rolling.helper.TimeBasedArchiveRemover - first clean up after appender initialization
09:05:54,009 |-INFO in ch.qos.logback.core.model.processor.ImplicitModelHandler - Assuming default type [ch.qos.logback.classic.encoder.PatternLayoutEncoder] for [encoder] property
09:05:54,009 |-INFO in c.q.l.core.rolling.helper.TimeBasedArchiveRemover - Multiple periods, i.e. 32 periods, seem to have elapsed. This is expected at application start.
09:05:54,009 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@22aee519 - value "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n" substituted for "${LOG_PATTERN}"
09:05:54,010 |-INFO in ch.qos.logback.core.rolling.RollingFileAppender[APP_FILE] - Active log file name: logs/app.log
09:05:54,011 |-INFO in ch.qos.logback.core.rolling.RollingFileAppender[APP_FILE] - Setting currentFileLength to 2718 for logs/app.log
09:05:54,011 |-INFO in ch.qos.logback.core.rolling.RollingFileAppender[APP_FILE] - File property is set to [logs/app.log]
09:05:54,011 |-INFO in ch.qos.logback.core.model.processor.AppenderModelHandler - Processing appender named [WARN_FILE]
09:05:54,011 |-INFO in ch.qos.logback.core.model.processor.AppenderModelHandler - About to instantiate appender of type [ch.qos.logback.core.rolling.RollingFileAppender]
09:05:54,011 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@22aee519 - value "logs/warn.log" substituted for "${LOG_DIR}/warn.log"
09:05:54,012 |-INFO in c.q.l.core.rolling.helper.TimeBasedArchiveRemover - No removal attempts were made.
09:05:54,012 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@22aee519 - value "logs/archive/warn.%d{yyyy-MM-dd}.%i.log.gz" substituted for "${LOG_DIR}/archive/warn.%d{yyyy-MM-dd}.%i.log.gz"
09:05:54,012 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@22aee519 - value "20MB" substituted for "${LOG_MAX_FILE_SIZE}"
09:05:54,012 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@22aee519 - value "30" substituted for "${LOG_MAX_HISTORY_DAYS}"
09:05:54,012 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@22aee519 - value "3GB" substituted for "${LOG_TOTAL_SIZE_CAP}"
09:05:54,012 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@816784381 - setting totalSizeCap to 3 GB
09:05:54,012 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@816784381 - Archive files will be limited to [20 MB] each.
09:05:54,013 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@816784381 - Will use gz compression
09:05:54,013 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@816784381 - Will use the pattern logs/archive/warn.%d{yyyy-MM-dd}.%i.log for the active file
09:05:54,013 |-INFO in ch.qos.logback.core.rolling.SizeAndTimeBasedFileNamingAndTriggeringPolicy@65fc8edc - The date pattern is 'yyyy-MM-dd' from file name pattern 'logs/archive/warn.%d{yyyy-MM-dd}.%i.log.gz'.
09:05:54,013 |-INFO in ch.qos.logback.core.rolling.SizeAndTimeBasedFileNamingAndTriggeringPolicy@65fc8edc - Roll-over at midnight.
09:05:54,013 |-INFO in ch.qos.logback.core.rolling.SizeAndTimeBasedFileNamingAndTriggeringPolicy@65fc8edc - Setting initial period to 2026-02-26T01:05:43.292Z
09:05:54,013 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@816784381 - Cleaning on start up
09:05:54,013 |-INFO in c.q.l.core.rolling.helper.TimeBasedArchiveRemover - first clean up after appender initialization
09:05:54,013 |-INFO in ch.qos.logback.core.model.processor.ImplicitModelHandler - Assuming default type [ch.qos.logback.classic.encoder.PatternLayoutEncoder] for [encoder] property
09:05:54,013 |-INFO in c.q.l.core.rolling.helper.TimeBasedArchiveRemover - Multiple periods, i.e. 32 periods, seem to have elapsed. This is expected at application start.
09:05:54,013 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@22aee519 - value "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n" substituted for "${LOG_PATTERN}"
09:05:54,013 |-INFO in ch.qos.logback.core.rolling.RollingFileAppender[WARN_FILE] - Active log file name: logs/warn.log
09:05:54,013 |-INFO in ch.qos.logback.core.rolling.RollingFileAppender[WARN_FILE] - Setting currentFileLength to 614 for logs/warn.log
09:05:54,013 |-INFO in ch.qos.logback.core.rolling.RollingFileAppender[WARN_FILE] - File property is set to [logs/warn.log]
09:05:54,013 |-INFO in ch.qos.logback.core.model.processor.AppenderModelHandler - Processing appender named [ERROR_FILE]
09:05:54,013 |-INFO in ch.qos.logback.core.model.processor.AppenderModelHandler - About to instantiate appender of type [ch.qos.logback.core.rolling.RollingFileAppender]
09:05:54,013 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@22aee519 - value "logs/error.log" substituted for "${LOG_DIR}/error.log"
09:05:54,015 |-INFO in c.q.l.core.rolling.helper.TimeBasedArchiveRemover - No removal attempts were made.
09:05:54,015 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@22aee519 - value "logs/archive/error.%d{yyyy-MM-dd}.%i.log.gz" substituted for "${LOG_DIR}/archive/error.%d{yyyy-MM-dd}.%i.log.gz"
09:05:54,015 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@22aee519 - value "20MB" substituted for "${LOG_MAX_FILE_SIZE}"
09:05:54,015 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@22aee519 - value "30" substituted for "${LOG_MAX_HISTORY_DAYS}"
09:05:54,015 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@22aee519 - value "3GB" substituted for "${LOG_TOTAL_SIZE_CAP}"
09:05:54,015 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@171277374 - setting totalSizeCap to 3 GB
09:05:54,015 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@171277374 - Archive files will be limited to [20 MB] each.
09:05:54,015 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@171277374 - Will use gz compression
09:05:54,015 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@171277374 - Will use the pattern logs/archive/error.%d{yyyy-MM-dd}.%i.log for the active file
09:05:54,015 |-INFO in ch.qos.logback.core.rolling.SizeAndTimeBasedFileNamingAndTriggeringPolicy@7740b0ab - The date pattern is 'yyyy-MM-dd' from file name pattern 'logs/archive/error.%d{yyyy-MM-dd}.%i.log.gz'.
09:05:54,015 |-INFO in ch.qos.logback.core.rolling.SizeAndTimeBasedFileNamingAndTriggeringPolicy@7740b0ab - Roll-over at midnight.
09:05:54,015 |-INFO in ch.qos.logback.core.rolling.SizeAndTimeBasedFileNamingAndTriggeringPolicy@7740b0ab - Setting initial period to 2026-02-26T01:05:43.292Z
09:05:54,015 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@171277374 - Cleaning on start up
09:05:54,016 |-INFO in c.q.l.core.rolling.helper.TimeBasedArchiveRemover - first clean up after appender initialization
09:05:54,016 |-INFO in ch.qos.logback.core.model.processor.ImplicitModelHandler - Assuming default type [ch.qos.logback.classic.encoder.PatternLayoutEncoder] for [encoder] property
09:05:54,016 |-INFO in c.q.l.core.rolling.helper.TimeBasedArchiveRemover - Multiple periods, i.e. 32 periods, seem to have elapsed. This is expected at application start.
09:05:54,016 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@22aee519 - value "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n" substituted for "${LOG_PATTERN}"
09:05:54,016 |-INFO in ch.qos.logback.core.rolling.RollingFileAppender[ERROR_FILE] - Active log file name: logs/error.log
09:05:54,016 |-INFO in ch.qos.logback.core.rolling.RollingFileAppender[ERROR_FILE] - Setting currentFileLength to 264 for logs/error.log
09:05:54,016 |-INFO in ch.qos.logback.core.rolling.RollingFileAppender[ERROR_FILE] - File property is set to [logs/error.log]
09:05:54,016 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@22aee519 - value "INFO" substituted for "${APP_LOG_LEVEL}"
09:05:54,016 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [ltdjms.discord] to INFO
09:05:54,016 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [ltdjms.discord.currency.bot] to INFO
09:05:54,016 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [ltdjms.discord.currency.commands] to INFO
09:05:54,016 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [ltdjms.discord.currency.services] to INFO
09:05:54,016 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [ltdjms.discord.currency.persistence] to INFO
09:05:54,016 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [ltdjms.discord.discord] to INFO
09:05:54,016 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [ltdjms.discord.discord.adapter] to DEBUG
09:05:54,016 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [ltdjms.discord.aichat] to INFO
09:05:54,016 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [ltdjms.discord.aichat.commands] to INFO
09:05:54,016 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [ltdjms.discord.aichat.services] to INFO
09:05:54,016 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [net.dv8tion.jda] to INFO
09:05:54,017 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [net.dv8tion.jda.internal.requests] to WARN
09:05:54,017 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [net.dv8tion.jda.api.requests] to WARN
09:05:54,017 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [com.zaxxer.hikari] to INFO
09:05:54,017 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [com.zaxxer.hikari.pool] to INFO
09:05:54,017 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [org.postgresql] to WARN
09:05:54,017 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@22aee519 - value "WARN" substituted for "${LOG_LEVEL}"
09:05:54,017 |-INFO in c.q.l.core.rolling.helper.TimeBasedArchiveRemover - No removal attempts were made.
09:05:54,017 |-INFO in ch.qos.logback.classic.model.processor.RootLoggerModelHandler - Setting level of ROOT logger to WARN
09:05:54,017 |-INFO in ch.qos.logback.core.model.processor.AppenderRefModelHandler - Attaching appender named [CONSOLE] to Logger[ROOT]
09:05:54,017 |-INFO in ch.qos.logback.core.model.processor.AppenderRefModelHandler - Attaching appender named [APP_FILE] to Logger[ROOT]
09:05:54,017 |-INFO in ch.qos.logback.core.model.processor.AppenderRefModelHandler - Attaching appender named [WARN_FILE] to Logger[ROOT]
09:05:54,017 |-INFO in ch.qos.logback.core.model.processor.AppenderRefModelHandler - Attaching appender named [ERROR_FILE] to Logger[ROOT]
09:05:54,017 |-INFO in ch.qos.logback.core.model.processor.DefaultProcessor@3eb9c575 - End of configuration.
09:05:54,018 |-INFO in ch.qos.logback.classic.joran.JoranConfigurator@3f322610 - Registering current configuration as safe fallback point
09:05:54,018 |-INFO in ch.qos.logback.classic.util.ContextInitializer@4f402027 - ch.qos.logback.classic.util.DefaultJoranConfigurator.configure() call lasted 141 milliseconds. ExecutionStatus=DO_NOT_INVOKE_NEXT_IF_ANY

2026-02-26 09:05:54.244 [main] WARN  l.d.r.services.RedemptionService - Redemption code became unavailable during redeem attempt: code=ABCD****5678, userId=987654321098765432
2026-02-26 09:05:54.255 [main] ERROR l.d.r.services.RedemptionService - Redemption code ID is null during redeem: code=ABCD****5678
2026-02-26 09:05:54.267 [main] INFO  l.d.r.services.RedemptionService - Successfully redeemed code ABCD****5678 by user 987654321098765432 for product Test
2026-02-26 09:05:54.271 [main] INFO  l.d.r.services.RedemptionService - Successfully redeemed code ABCD****5678 by user 987654321098765432 for product VIP 服務
2026-02-26 09:05:54.278 [main] INFO  l.d.r.services.RedemptionService - Successfully redeemed code ABCD****5678 by user 987654321098765432 for product 禮包
2026-02-26 09:05:54.281 [main] INFO  l.d.r.services.RedemptionService - Successfully redeemed code ABCD****5678 by user 987654321098765432 for product 代幣包
2026-02-26 09:05:54.283 [main] INFO  l.d.r.services.RedemptionService - Successfully redeemed code ABC by user 987654321098765432 for product 禮包
2026-02-26 09:05:54.313 [main] INFO  l.d.r.services.RedemptionService - Generated 2 redemption codes for productId=1 with quantity=1
2026-02-26 09:05:54.318 [main] INFO  l.d.r.services.RedemptionService - Generated 2 redemption codes for productId=1 with quantity=5

### Test Cases (for complex changes)
- N/A
