### PR TITLE
fix: prevent redemption reward overflow before code redemption

### DIFF
--- a/src/main/java/ltdjms/discord/redemption/services/ProductRedemptionTransactionService.java
+++ b/src/main/java/ltdjms/discord/redemption/services/ProductRedemptionTransactionService.java
@@ -42,7 +42,16 @@ public class ProductRedemptionTransactionService {
     ProductRedemptionTransaction.RewardType rewardType = null;
 
     if (product.hasReward()) {
-      rewardAmount = product.rewardAmount() * redemptionCode.quantity();
+      try {
+        rewardAmount = Math.multiplyExact(product.rewardAmount(), redemptionCode.quantity());
+      } catch (ArithmeticException e) {
+        throw new IllegalArgumentException(
+            "Reward amount overflow: reward="
+                + product.rewardAmount()
+                + ", quantity="
+                + redemptionCode.quantity(),
+            e);
+      }
       rewardType =
           switch (product.rewardType()) {
             case CURRENCY -> ProductRedemptionTransaction.RewardType.CURRENCY;

--- a/src/main/java/ltdjms/discord/redemption/services/RedemptionService.java
+++ b/src/main/java/ltdjms/discord/redemption/services/RedemptionService.java
@@ -209,6 +209,15 @@ public class RedemptionService {
 
     Product product = productOpt.get();
 
+    Long totalRewardAmount = null;
+    if (product.hasReward()) {
+      Result<Long, DomainError> rewardAmountResult = calculateTotalRewardAmount(product, code);
+      if (rewardAmountResult.isErr()) {
+        return Result.err(rewardAmountResult.getError());
+      }
+      totalRewardAmount = rewardAmountResult.getValue();
+    }
+
     try {
       // Mark code as redeemed
       if (code.id() == null) {
@@ -231,7 +240,8 @@ public class RedemptionService {
       // Grant reward if applicable
       Long rewardedAmount = null;
       if (product.hasReward()) {
-        Result<Long, DomainError> rewardResult = grantReward(guildId, userId, product, code);
+        Result<Long, DomainError> rewardResult =
+            grantReward(guildId, userId, product, code, totalRewardAmount);
         if (rewardResult.isErr()) {
           // Rollback the redemption would be complex, log and continue
           LOG.error(
@@ -332,14 +342,17 @@ public class RedemptionService {
 
   /** Grants the reward for a product. */
   private Result<Long, DomainError> grantReward(
-      long guildId, long userId, Product product, RedemptionCode code) {
+      long guildId, long userId, Product product, RedemptionCode code, Long totalRewardAmount) {
 
     if (!product.hasReward()) {
       return Result.ok(null);
     }
 
-    // Calculate total reward based on quantity
-    long totalAmount = product.rewardAmount() * code.quantity();
+    if (totalRewardAmount == null) {
+      return Result.err(DomainError.invalidInput("商品獎勵金額無效"));
+    }
+
+    long totalAmount = totalRewardAmount;
     String description =
         String.format("兌換碼: %s (%s) x%d", code.getMaskedCode(), product.name(), code.quantity());
 
@@ -375,6 +388,19 @@ public class RedemptionService {
         yield Result.err(tokenResult.getError());
       }
     };
+  }
+
+  private Result<Long, DomainError> calculateTotalRewardAmount(
+      Product product, RedemptionCode code) {
+    try {
+      long totalAmount = Math.multiplyExact(product.rewardAmount(), code.quantity());
+      if (totalAmount <= 0) {
+        return Result.err(DomainError.invalidInput("商品獎勵金額無效"));
+      }
+      return Result.ok(totalAmount);
+    } catch (ArithmeticException e) {
+      return Result.err(DomainError.invalidInput("商品獎勵計算超出範圍"));
+    }
   }
 
   /** Result of a successful redemption. */

--- a/src/test/java/ltdjms/discord/redemption/services/ProductRedemptionTransactionServiceTest.java
+++ b/src/test/java/ltdjms/discord/redemption/services/ProductRedemptionTransactionServiceTest.java
@@ -158,6 +158,32 @@ class ProductRedemptionTransactionServiceTest {
       assertThat(result.rewardAmount()).isNull();
       verify(transactionRepository).save(any(ProductRedemptionTransaction.class));
     }
+
+    @Test
+    @DisplayName("should reject overflowed reward amount")
+    void shouldRejectOverflowedRewardAmount() {
+      // Given
+      Product product =
+          new Product(
+              TEST_PRODUCT_ID,
+              TEST_GUILD_ID,
+              "超大獎勵",
+              "overflow test",
+              Product.RewardType.CURRENCY,
+              Long.MAX_VALUE,
+              null,
+              Instant.now(),
+              Instant.now());
+      RedemptionCode code =
+          RedemptionCode.create("OVERFLOW", TEST_PRODUCT_ID, TEST_GUILD_ID, null, 2);
+
+      // When / Then
+      assertThatThrownBy(
+              () -> service.recordTransaction(TEST_GUILD_ID, TEST_USER_ID, product, code))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("overflow");
+      verify(transactionRepository, never()).save(any(ProductRedemptionTransaction.class));
+    }
   }
 
   @Nested

--- a/src/test/java/ltdjms/discord/redemption/services/RedemptionServiceTest.java
+++ b/src/test/java/ltdjms/discord/redemption/services/RedemptionServiceTest.java
@@ -699,6 +699,49 @@ class RedemptionServiceTest {
   class RedeemCodeFailureTests {
 
     @Test
+    @DisplayName("should reject overflowed reward before marking code redeemed")
+    void shouldRejectOverflowedRewardBeforeMarkingCodeRedeemed() {
+      // Given
+      Instant now = Instant.now();
+      Product product =
+          new Product(
+              Long.valueOf(TEST_PRODUCT_ID),
+              TEST_GUILD_ID,
+              "超大獎勵禮包",
+              null,
+              Product.RewardType.CURRENCY,
+              Long.MAX_VALUE,
+              null,
+              now,
+              now);
+      RedemptionCode code =
+          new RedemptionCode(
+              1L,
+              "ABCD1234EFGH5678",
+              TEST_PRODUCT_ID,
+              TEST_GUILD_ID,
+              null,
+              null,
+              null,
+              now,
+              null,
+              2);
+
+      when(codeRepository.findByCode("ABCD1234EFGH5678")).thenReturn(Optional.of(code));
+      when(productRepository.findById(TEST_PRODUCT_ID)).thenReturn(Optional.of(product));
+
+      // When
+      Result<RedemptionService.RedemptionResult, DomainError> result =
+          redemptionService.redeemCode("ABCD1234EFGH5678", TEST_GUILD_ID, TEST_USER_ID);
+
+      // Then
+      assertThat(result.isErr()).isTrue();
+      assertThat(result.getError().message()).contains("獎勵");
+      verify(codeRepository, never()).markAsRedeemedIfAvailable(anyLong(), anyLong(), any());
+      verify(balanceAdjustmentService, never()).tryAdjustBalance(anyLong(), anyLong(), anyLong());
+    }
+
+    @Test
     @DisplayName("should reject blank code")
     void shouldRejectBlankCode() {
       // When


### PR DESCRIPTION
## Motivation
- close an exploitable integer-overflow path in redemption reward calculations
- preserve redemption invariants (no side effects before reward amount is proven safe)

## What changed
- pre-compute redemption total reward with Math.multiplyExact before marking codes as redeemed
- return a domain validation error when reward computation overflows or becomes invalid
- reuse the pre-validated reward amount during reward grant to avoid duplicate unsafe math
- harden transaction snapshot creation with overflow-safe multiplication

## Tests
- mvn -q -Dtest=RedemptionServiceTest,ProductRedemptionTransactionServiceTest test
- added regression tests for overflow scenarios in both services
