### PR TITLE
Handle null permission entries in create channel tool

### DIFF
--- a/src/main/java/ltdjms/discord/aiagent/services/tools/LangChain4jCreateChannelTool.java
+++ b/src/main/java/ltdjms/discord/aiagent/services/tools/LangChain4jCreateChannelTool.java
@@ -333,8 +333,13 @@ public final class LangChain4jCreateChannelTool {
    */
   private void applyPermissions(
       TextChannel channel, List<PermissionSetting> permissionsParam, Guild guild) {
-    try {
-      for (PermissionSetting setting : permissionsParam) {
+    for (PermissionSetting setting : permissionsParam) {
+      if (setting == null) {
+        LOGGER.warn("LangChain4jCreateChannelTool: 權限設定包含 null，已跳過");
+        continue;
+      }
+
+      try {
         long roleId = setting.roleId();
         Role role = guild.getRoleById(roleId);
         if (role == null) {
@@ -344,11 +349,11 @@ public final class LangChain4jCreateChannelTool {
 
         ChannelPermission permission = PermissionParser.parse(setting);
         applyPermissionToChannel(channel, role, permission.permissionSet());
+      } catch (Exception e) {
+        LOGGER.warn("LangChain4jCreateChannelTool: 應用單筆權限時發生錯誤: {}", e.getMessage());
+        // 單筆權限失敗不影響其他權限設定與頻道創建
+        continue;
       }
-
-    } catch (Exception e) {
-      LOGGER.warn("LangChain4jCreateChannelTool: 應用權限時發生錯誤: {}", e.getMessage());
-      // 權限應用失敗不影響頻道創建，僅記錄警告
     }
   }
 

--- a/src/test/java/ltdjms/discord/aiagent/unit/services/tools/LangChain4jCreateChannelToolTest.java
+++ b/src/test/java/ltdjms/discord/aiagent/unit/services/tools/LangChain4jCreateChannelToolTest.java
@@ -2,8 +2,10 @@ package ltdjms.discord.aiagent.unit.services.tools;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -569,6 +571,35 @@ class LangChain4jCreateChannelToolTest {
 
       // Then
       assertThat(result).contains("\"success\": true");
+    }
+
+    @Test
+    @DisplayName("當權限列表含有 null 時，仍應處理其餘有效設定")
+    void shouldContinueApplyingPermissionsWhenListContainsNull() {
+      // Given
+      String channelName = "null-entry-perms-channel";
+      when(mockGuild.getRoleById(TEST_ROLE_ID)).thenReturn(null);
+
+      ChannelAction<TextChannel> channelAction = mockChannelAction();
+      when(mockGuild.createTextChannel(channelName)).thenReturn(channelAction);
+      setupSuccessfulRestAction(channelAction, mockTextChannel);
+
+      when(mockTextChannel.getIdLong()).thenReturn(TEST_CHANNEL_ID);
+      when(mockTextChannel.getName()).thenReturn(channelName);
+
+      PermissionSetting validPermission =
+          new PermissionSetting(TEST_ROLE_ID, Set.of(PermissionEnum.VIEW_CHANNEL), Set.of());
+      List<PermissionSetting> permissions = new ArrayList<>();
+      permissions.add(null);
+      permissions.add(validPermission);
+
+      // When
+      String result =
+          tool.createChannel(channelName, null, permissions, createMockInvocationParameters());
+
+      // Then
+      assertThat(result).contains("\"success\": true");
+      verify(mockGuild).getRoleById(TEST_ROLE_ID);
     }
 
     @Test


### PR DESCRIPTION
## Related issues
- Edge-case hardening automation run (no linked issue).

## What changed
- Hardened `LangChain4jCreateChannelTool.applyPermissions` to skip `null` entries instead of aborting the entire permission application loop.
- Scoped exception handling to each permission item so one malformed permission does not block remaining valid permissions.
- Added unit test coverage for mixed permission list input containing a `null` entry and a valid entry.

## Why
- AI-generated permission arrays can contain malformed items. Previously, a single `null` entry caused the whole permission application loop to exit early, silently skipping valid entries.

## Test results
- `mvn -Dtest=LangChain4jCreateChannelToolTest test`
