### PR TITLE
fix: guard null choice entries in AI stream chunks

### DIFF
--- a/src/main/java/ltdjms/discord/aichat/domain/AIChatStreamChunk.java
+++ b/src/main/java/ltdjms/discord/aichat/domain/AIChatStreamChunk.java
@@ -55,7 +55,7 @@ public record AIChatStreamChunk(
       return null;
     }
     StreamChoice choice = choices.get(0);
-    if (choice.delta() == null) {
+    if (choice == null || choice.delta() == null) {
       return null;
     }
     return choice.delta().content();
@@ -67,7 +67,7 @@ public record AIChatStreamChunk(
       return null;
     }
     StreamChoice choice = choices.get(0);
-    if (choice.delta() == null) {
+    if (choice == null || choice.delta() == null) {
       return null;
     }
     return choice.delta().reasoningContent();
@@ -79,6 +79,9 @@ public record AIChatStreamChunk(
       return false;
     }
     StreamChoice choice = choices.get(0);
+    if (choice == null) {
+      return false;
+    }
     return "stop".equals(choice.finishReason());
   }
 }

--- a/src/test/java/ltdjms/discord/aichat/unit/AIChatStreamChunkTest.java
+++ b/src/test/java/ltdjms/discord/aichat/unit/AIChatStreamChunkTest.java
@@ -163,6 +163,29 @@ class AIChatStreamChunkTest {
     assertThat(reasoningContent).isNull();
   }
 
+  @Test
+  void testExtractMethods_withNullChoiceElement_shouldHandleGracefully() {
+    // Given
+    String json =
+        """
+        {
+          "id": "test-id",
+          "object": "chat.completion.chunk",
+          "created": 1234567890,
+          "model": "test-model",
+          "choices": [null]
+        }
+        """;
+
+    // When
+    AIChatStreamChunk chunk = parseJson(json);
+
+    // Then
+    assertThat(chunk.extractContent()).isNull();
+    assertThat(chunk.extractReasoningContent()).isNull();
+    assertThat(chunk.isFinished()).isFalse();
+  }
+
   private AIChatStreamChunk parseJson(String json) {
     try {
       com.fasterxml.jackson.databind.ObjectMapper mapper =


### PR DESCRIPTION
## Related Issues / Motivation
- Automated edge-case scan found an unhandled malformed payload scenario in streaming chat chunks.
- When choices contains a null entry (e.g. [null]), extracting content/reasoning or checking finish status throws NullPointerException.

## Engineering Decisions
- Added defensive null checks for the first StreamChoice before accessing delta or finishReason in AIChatStreamChunk.
- Added a regression test with choices: [null] to lock in graceful behavior.
- Kept behavior backward-compatible: methods now return null/false instead of throwing.

## Edge Cases Covered
- choices list exists but first element is null.
  - extractContent() => null
  - extractReasoningContent() => null
  - isFinished() => false

## Test Results
- mvn -Dtest=AIChatStreamChunkTest,AIChatResponseTest test
- mvn test
