### PR TITLE
fix: prevent cross-product invalidated code exposure

### DIFF
--- a/src/main/java/ltdjms/discord/redemption/persistence/JdbcRedemptionCodeRepository.java
+++ b/src/main/java/ltdjms/discord/redemption/persistence/JdbcRedemptionCodeRepository.java
@@ -454,7 +454,7 @@ public class JdbcRedemptionCodeRepository implements RedemptionCodeRepository {
   public int invalidateByProductId(long productId) {
     String sql =
         "UPDATE redemption_code "
-            + "SET product_id = NULL, invalidated_at = NOW() "
+            + "SET invalidated_at = NOW() "
             + "WHERE product_id = ? AND invalidated_at IS NULL";
 
     try (Connection conn = dataSource.getConnection();
@@ -478,30 +478,20 @@ public class JdbcRedemptionCodeRepository implements RedemptionCodeRepository {
   public List<RedemptionCode> findInvalidatedByProductId(long productId) {
     String sql =
         "SELECT id, code, product_id, guild_id, expires_at, redeemed_by, redeemed_at, created_at,"
-            + " invalidated_at FROM redemption_code WHERE product_id IS NULL AND id IN (  SELECT"
-            + " unnest(string_to_array(substring, ' '))::bigint   FROM (    SELECT"
-            + " string_agg(id::text, ' ') as substring     FROM redemption_code     WHERE"
-            + " invalidated_at IS NOT NULL  ) x)";
-
-    // Simplified query for invalidated codes - find codes where product_id is NULL
-    String simplifiedSql =
-        "SELECT id, code, product_id, guild_id, expires_at, redeemed_by, redeemed_at, created_at,"
-            + " invalidated_at, quantity FROM redemption_code WHERE invalidated_at IS NOT NULL"
+            + " invalidated_at, quantity FROM redemption_code WHERE product_id = ? AND"
+            + " invalidated_at IS NOT NULL"
             + " ORDER BY invalidated_at DESC";
 
     List<RedemptionCode> codes = new ArrayList<>();
 
     try (Connection conn = dataSource.getConnection();
-        PreparedStatement stmt = conn.prepareStatement(simplifiedSql)) {
+        PreparedStatement stmt = conn.prepareStatement(sql)) {
+
+      stmt.setLong(1, productId);
 
       try (ResultSet rs = stmt.executeQuery()) {
         while (rs.next()) {
-          RedemptionCode code = mapRow(rs);
-          // Filter by checking if this code originally belonged to the product
-          // Since product_id is NULL after invalidation, we need to check through a different
-          // approach
-          // For now, return all invalidated codes and filter in service layer if needed
-          codes.add(code);
+          codes.add(mapRow(rs));
         }
       }
 

--- a/src/test/java/ltdjms/discord/redemption/persistence/JdbcRedemptionCodeRepositoryTest.java
+++ b/src/test/java/ltdjms/discord/redemption/persistence/JdbcRedemptionCodeRepositoryTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -27,6 +28,7 @@ class JdbcRedemptionCodeRepositoryTest {
 
   private static final long TEST_CODE_ID = 1L;
   private static final long TEST_USER_ID = 987654321098765432L;
+  private static final long TEST_PRODUCT_ID = 42L;
 
   private DataSource dataSource;
   private Connection connection;
@@ -125,6 +127,46 @@ class JdbcRedemptionCodeRepositoryTest {
                       TEST_CODE_ID, TEST_USER_ID, Instant.parse("2026-02-01T00:00:00Z")))
           .isInstanceOf(RepositoryException.class)
           .hasMessageContaining("Failed to atomically redeem code");
+    }
+  }
+
+  @Nested
+  @DisplayName("invalidated code queries")
+  class InvalidatedCodeQueryTests {
+
+    @Test
+    @DisplayName("invalidateByProductId 不應清空 product_id，避免後續查詢失去產品邊界")
+    void invalidateByProductIdShouldNotNullOutProductId() throws SQLException {
+      PreparedStatement stmt = mock(PreparedStatement.class);
+      ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+
+      when(connection.prepareStatement(sqlCaptor.capture())).thenReturn(stmt);
+      when(stmt.executeUpdate()).thenReturn(1);
+
+      int affected = repository.invalidateByProductId(TEST_PRODUCT_ID);
+
+      assertThat(affected).isEqualTo(1);
+      assertThat(sqlCaptor.getValue()).contains("SET invalidated_at = NOW()");
+      assertThat(sqlCaptor.getValue()).doesNotContain("product_id = NULL");
+      verify(stmt).setLong(1, TEST_PRODUCT_ID);
+    }
+
+    @Test
+    @DisplayName("findInvalidatedByProductId 應只查詢指定 product_id 的失效碼")
+    void findInvalidatedByProductIdShouldScopeByProductId() throws SQLException {
+      PreparedStatement stmt = mock(PreparedStatement.class);
+      ResultSet rs = mock(ResultSet.class);
+      ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+
+      when(connection.prepareStatement(sqlCaptor.capture())).thenReturn(stmt);
+      when(stmt.executeQuery()).thenReturn(rs);
+      when(rs.next()).thenReturn(false);
+
+      repository.findInvalidatedByProductId(TEST_PRODUCT_ID);
+
+      assertThat(sqlCaptor.getValue())
+          .contains("WHERE product_id = ? AND invalidated_at IS NOT NULL");
+      verify(stmt).setLong(1, TEST_PRODUCT_ID);
     }
   }
 }


### PR DESCRIPTION
## Related issue / motivation
Security hardening: `findInvalidatedByProductId` previously used a fallback query that returned **all** invalidated redemption codes, which could leak invalidated-code metadata across products.

## Engineering decisions
- Kept invalidation metadata scoped to the original product by stopping `invalidateByProductId` from nulling `product_id`.
- Replaced the fallback `findInvalidatedByProductId` SQL with a strict `product_id = ? AND invalidated_at IS NOT NULL` filter.
- Added repository regression tests that assert:
  - invalidation SQL does not clear `product_id`
  - invalidated lookup is parameterized and scoped by `product_id`

This is the smallest patch that closes the data-exposure path without broad refactors.

## Test results
- `mvn -q -Dtest=JdbcRedemptionCodeRepositoryTest test` ✅
