### PR TITLE
fix: harden chat memory conversation-id parsing

### DIFF
--- a/src/main/java/ltdjms/discord/aiagent/services/SimplifiedChatMemoryProvider.java
+++ b/src/main/java/ltdjms/discord/aiagent/services/SimplifiedChatMemoryProvider.java
@@ -75,23 +75,31 @@ public final class SimplifiedChatMemoryProvider implements ChatMemoryProvider {
    */
   @Override
   public ChatMemory get(Object memoryId) {
-    String conversationId = (String) memoryId;
+    if (!(memoryId instanceof String conversationId) || conversationId.isBlank()) {
+      LOG.warn("無效的會話 ID 物件，使用空記憶體: {}", memoryId);
+      return createNonThreadMemory(String.valueOf(memoryId));
+    }
 
     // 檢查是否為 Thread 級別會話
-    if (!ConversationIdBuilder.isThreadLevel(conversationId)) {
+    if (!isThreadLevelConversation(conversationId)) {
       // 非 Thread，返回空記憶體（短期上下文）
       LOG.debug("非 Thread 級別會話，使用空記憶體: {}", conversationId);
-      return MessageWindowChatMemory.builder()
-          .id(conversationId)
-          .maxMessages(NON_THREAD_MAX_MESSAGES)
-          .build();
+      return createNonThreadMemory(conversationId);
     }
 
     // 解析 guildId, threadId, userId
-    String[] parts = conversationId.split(":");
-    long guildId = Long.parseLong(parts[0]);
-    long threadId = Long.parseLong(parts[1]);
-    long userId = Long.parseLong(parts[2]);
+    long guildId;
+    long threadId;
+    long userId;
+    try {
+      String[] parts = conversationId.split(":");
+      guildId = Long.parseLong(parts[0]);
+      threadId = Long.parseLong(parts[1]);
+      userId = Long.parseLong(parts[2]);
+    } catch (RuntimeException e) {
+      LOG.warn("無法解析 Thread 級別會話 ID，改用空記憶體: {}", conversationId);
+      return createNonThreadMemory(conversationId);
+    }
 
     LOG.debug("Thread 級別會話: guildId={}, threadId={}, userId={}", guildId, threadId, userId);
 
@@ -130,5 +138,21 @@ public final class SimplifiedChatMemoryProvider implements ChatMemoryProvider {
         toolCallMessages.size());
 
     return memory;
+  }
+
+  private boolean isThreadLevelConversation(String conversationId) {
+    try {
+      return ConversationIdBuilder.isThreadLevel(conversationId);
+    } catch (IllegalArgumentException e) {
+      LOG.warn("會話 ID 格式無效，改用空記憶體: {}", conversationId);
+      return false;
+    }
+  }
+
+  private ChatMemory createNonThreadMemory(Object memoryId) {
+    return MessageWindowChatMemory.builder()
+        .id(memoryId == null ? "null" : String.valueOf(memoryId))
+        .maxMessages(NON_THREAD_MAX_MESSAGES)
+        .build();
   }
 }

--- a/src/test/java/ltdjms/discord/aiagent/unit/services/SimplifiedChatMemoryProviderTest.java
+++ b/src/test/java/ltdjms/discord/aiagent/unit/services/SimplifiedChatMemoryProviderTest.java
@@ -1,0 +1,85 @@
+package ltdjms.discord.aiagent.unit.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import dev.langchain4j.data.message.UserMessage;
+import ltdjms.discord.aiagent.services.DiscordThreadHistoryProvider;
+import ltdjms.discord.aiagent.services.InMemoryToolCallHistory;
+import ltdjms.discord.aiagent.services.SimplifiedChatMemoryProvider;
+import ltdjms.discord.shared.di.JDAProvider;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.SelfUser;
+
+@DisplayName("SimplifiedChatMemoryProvider")
+class SimplifiedChatMemoryProviderTest {
+
+  private DiscordThreadHistoryProvider threadHistoryProvider;
+  private InMemoryToolCallHistory toolCallHistory;
+  private SimplifiedChatMemoryProvider provider;
+
+  @BeforeEach
+  void setUp() {
+    threadHistoryProvider = mock(DiscordThreadHistoryProvider.class);
+    toolCallHistory = mock(InMemoryToolCallHistory.class);
+    provider = new SimplifiedChatMemoryProvider(threadHistoryProvider, toolCallHistory);
+  }
+
+  @AfterEach
+  void tearDown() {
+    JDAProvider.clear();
+  }
+
+  @Test
+  @DisplayName("當 memoryId 不是字串時應回退為非 Thread 記憶體")
+  void shouldFallbackToNonThreadMemoryWhenMemoryIdIsNotString() {
+    var memory = provider.get(12345L);
+
+    assertThat(memory).isNotNull();
+    verify(threadHistoryProvider, never())
+        .getThreadHistory(anyLong(), anyLong(), anyLong(), anyLong());
+    verify(toolCallHistory, never()).getToolCallMessages(anyLong(), anyLong());
+  }
+
+  @Test
+  @DisplayName("當 Thread 級別 conversationId 非數字時應回退為非 Thread 記憶體")
+  void shouldFallbackToNonThreadMemoryWhenThreadConversationIdIsMalformed() {
+    var memory = provider.get("guild:thread:user");
+
+    assertThat(memory).isNotNull();
+    verify(threadHistoryProvider, never())
+        .getThreadHistory(anyLong(), anyLong(), anyLong(), anyLong());
+    verify(toolCallHistory, never()).getToolCallMessages(anyLong(), anyLong());
+  }
+
+  @Test
+  @DisplayName("合法 Thread 級別 conversationId 應正常載入歷史")
+  void shouldLoadThreadHistoryForValidThreadConversationId() {
+    JDA jda = mock(JDA.class);
+    SelfUser selfUser = mock(SelfUser.class);
+    when(selfUser.getIdLong()).thenReturn(900L);
+    when(jda.getSelfUser()).thenReturn(selfUser);
+    JDAProvider.setJda(jda);
+
+    when(threadHistoryProvider.getThreadHistory(100L, 200L, 300L, 900L))
+        .thenReturn(List.of(UserMessage.from("hello")));
+    when(toolCallHistory.getToolCallMessages(200L, 300L)).thenReturn(List.of());
+
+    var memory = provider.get("100:200:300");
+
+    assertThat(memory).isNotNull();
+    verify(threadHistoryProvider).getThreadHistory(100L, 200L, 300L, 900L);
+    verify(toolCallHistory).getToolCallMessages(200L, 300L);
+  }
+}


### PR DESCRIPTION
## Related Issues / Motivation
- Related: automation task "Check for edge cases"
- The chat memory provider assumed `memoryId` was always a valid numeric thread conversation ID. Malformed IDs could trigger runtime parsing failures in edge scenarios.

## Engineering Decisions and Rationale
- Added defensive guards in `SimplifiedChatMemoryProvider#get` for non-string/blank `memoryId` values.
- Wrapped thread-level detection and numeric parsing with safe fallbacks to non-thread memory instead of allowing exceptions to propagate.
- Kept behavior unchanged for valid thread conversation IDs and only hardened invalid-input paths.
- Added focused unit tests to verify fallback behavior and the normal valid-thread path.

## Test Results and Commands
- ✅ `mvn -q -Dtest=SimplifiedChatMemoryProviderTest test`
- ✅ `mvn -q -Dtest=AIAgentDomainTest,SimplifiedChatMemoryProviderTest test`

### Test Cases (for complex changes)
- Case 1: non-string `memoryId` -> should return non-thread memory and skip thread-history loading.
- Case 2: malformed thread-level ID (`guild:thread:user`) -> should fallback without exception.
- Case 3: valid thread-level ID (`100:200:300`) -> should load thread and tool history normally.
