### PR TITLE
Fix non-finite AI temperature env override handling

### DIFF
--- a/src/main/java/ltdjms/discord/shared/EnvironmentConfig.java
+++ b/src/main/java/ltdjms/discord/shared/EnvironmentConfig.java
@@ -283,7 +283,12 @@ public final class EnvironmentConfig {
     String value = dotEnvValues.get(envKey);
     if (value != null && !value.isBlank()) {
       try {
-        target.put(configPath, Double.parseDouble(value));
+        double parsed = Double.parseDouble(value);
+        if (Double.isFinite(parsed)) {
+          target.put(configPath, parsed);
+        } else {
+          LOG.warn("Invalid non-finite double value for {}: {}", envKey, value);
+        }
       } catch (NumberFormatException e) {
         LOG.warn("Invalid double value for {}: {}", envKey, value);
       }
@@ -324,7 +329,12 @@ public final class EnvironmentConfig {
     String value = System.getenv(envKey);
     if (value != null && !value.isBlank()) {
       try {
-        target.put(configPath, Double.parseDouble(value));
+        double parsed = Double.parseDouble(value);
+        if (Double.isFinite(parsed)) {
+          target.put(configPath, parsed);
+        } else {
+          LOG.warn("Invalid non-finite double value for {}: {}, using default", envKey, value);
+        }
       } catch (NumberFormatException e) {
         LOG.warn("Invalid double value for {}: {}, using default", envKey, value);
       }

--- a/src/test/java/ltdjms/discord/shared/EnvironmentConfigTest.java
+++ b/src/test/java/ltdjms/discord/shared/EnvironmentConfigTest.java
@@ -2,9 +2,12 @@ package ltdjms.discord.shared;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Tests for {@link EnvironmentConfig}.
@@ -12,6 +15,8 @@ import org.junit.jupiter.api.Test;
  * <p>These tests focus on default values when no environment overrides are present.
  */
 class EnvironmentConfigTest {
+
+  @TempDir Path tempDir;
 
   @Test
   void defaultDatabaseUrlUsesLocalCurrencyBotDatabase() {
@@ -22,5 +27,14 @@ class EnvironmentConfigTest {
     // When DB_URL is not set in the environment, we should fall back to the
     // hardcoded default JDBC URL instead of a placeholder literal.
     assertThat(config.getDatabaseUrl()).isEqualTo("jdbc:postgresql://localhost:5432/currency_bot");
+  }
+
+  @Test
+  void nonFiniteAiServiceTemperatureFallsBackToDefault() throws IOException {
+    Files.writeString(tempDir.resolve(".env"), "AI_SERVICE_TEMPERATURE=NaN\n");
+
+    EnvironmentConfig config = new EnvironmentConfig(tempDir);
+
+    assertThat(config.getAIServiceTemperature()).isEqualTo(0.7);
   }
 }


### PR DESCRIPTION
## Related Issues / Motivation
- Harden environment parsing for AI service temperature edge cases.
- Previously, non-finite values like NaN could pass parsing and override defaults.

## Engineering Decisions
- Reject non-finite doubles (NaN, Infinity, -Infinity) in both .env and system environment mappings.
- Keep behavior for finite doubles unchanged.
- Add a regression test to lock expected fallback behavior.

## Test Results
- mvn -q -Dtest=EnvironmentConfigTest test
- mvn -q -Dtest=EnvironmentConfigTest,AIServiceConfigTest test
