### PR TITLE
fix: guard blank agent completion responses

### DIFF
--- a/src/main/java/ltdjms/discord/aiagent/commands/AgentCompletionListener.java
+++ b/src/main/java/ltdjms/discord/aiagent/commands/AgentCompletionListener.java
@@ -53,14 +53,20 @@ public final class AgentCompletionListener implements Consumer<DomainEvent> {
       }
 
       List<String> messages = MessageSplitter.split(event.finalResponse());
+      int sentCount = 0;
       for (String message : messages) {
+        if (message == null || message.isBlank()) {
+          continue;
+        }
         channel.sendMessage(message).queue();
+        sentCount++;
+      }
+      if (sentCount == 0) {
+        channel.sendMessage(":question: AI 沒有產生回應").queue();
       }
 
       LOGGER.info(
-          "Agent 完成，已發送最終回應: conversationId={}, length={}",
-          event.conversationId(),
-          messages.size());
+          "Agent 完成，已發送最終回應: conversationId={}, length={}", event.conversationId(), sentCount);
 
     } catch (Exception e) {
       LOGGER.error("處理 Agent 完成事件時發生錯誤", e);

--- a/src/test/java/ltdjms/discord/aiagent/commands/AgentCompletionListenerTest.java
+++ b/src/test/java/ltdjms/discord/aiagent/commands/AgentCompletionListenerTest.java
@@ -175,6 +175,23 @@ class AgentCompletionListenerTest {
       // Then
       verify(threadChannel, never()).sendMessage(any(CharSequence.class));
     }
+
+    @Test
+    @DisplayName("should send fallback message when final response is blank")
+    void shouldSendFallbackMessageWhenFinalResponseIsBlank() {
+      // Given
+      when(jda.getGuildById(123L)).thenReturn(guild);
+      when(guild.getThreadChannelById(456L)).thenReturn(threadChannel);
+
+      AgentCompletedEvent event =
+          new AgentCompletedEvent(123L, "456", "789", "conv-123", "   ", List.of(), Instant.now());
+
+      // When
+      listener.accept(event);
+
+      // Then
+      verify(threadChannel).sendMessage(":question: AI 沒有產生回應");
+    }
   }
 
   @Nested


### PR DESCRIPTION
## Summary
- harden `AgentCompletionListener` against blank/null split chunks from final AI response
- skip blank chunks before sending Discord messages
- send fallback message `:question: AI 沒有產生回應` when no non-blank chunk exists
- add regression test for blank final response handling

## Edge Cases Covered
- `AgentCompletedEvent.finalResponse` is blank or whitespace-only
- splitter returns only blank chunks

## Tests
- `mvn -q -Dtest=AgentCompletionListenerTest test`
- `mvn -q -Dtest=AgentCompletionListenerTest,ToolExecutionListenerTest test`

## Risk Notes
- behavior change only applies when response content is blank
- non-blank completion flow remains unchanged
