### PR TITLE
fix: resolve issues #35 and #36

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,9 +72,10 @@ services:
     entrypoint: ["/bin/bash", "-c", "java $$JAVA_OPTS -jar app.jar"]
     volumes:
       - ./prompts:/app/prompts:ro
-      - ./logs:/app/logs
+      - bot_logs:/app/logs
     restart: unless-stopped
 
 volumes:
   redis_data:
   postgres_data:
+  bot_logs:

--- a/src/main/java/ltdjms/discord/panel/commands/AdminPanelButtonHandler.java
+++ b/src/main/java/ltdjms/discord/panel/commands/AdminPanelButtonHandler.java
@@ -125,6 +125,8 @@ public class AdminPanelButtonHandler extends ListenerAdapter {
       "admin_select_escort_pricing_panel_action";
   public static final String SELECT_ESCORT_PRICING_PANEL_OPTION =
       "admin_select_escort_pricing_panel_option";
+  public static final String SELECT_ESCORT_PRICING_PANEL_OPTION_EXTRA =
+      "admin_select_escort_pricing_panel_option_extra";
 
   private static final String ESCORT_PRICING_ACTION_UPDATE = "update";
   private static final String ESCORT_PRICING_ACTION_RESET = "reset";
@@ -277,6 +279,8 @@ public class AdminPanelButtonHandler extends ListenerAdapter {
         case SELECT_ESCORT_PRICING_PANEL_ACTION ->
             handleEscortPricingPanelActionSelect(event, sessionKey, guildId);
         case SELECT_ESCORT_PRICING_PANEL_OPTION ->
+            handleEscortPricingPanelOptionSelect(event, sessionKey, guildId);
+        case SELECT_ESCORT_PRICING_PANEL_OPTION_EXTRA ->
             handleEscortPricingPanelOptionSelect(event, sessionKey, guildId);
         default -> LOG.warn("Unknown string select: {}", selectId);
       }
@@ -1929,26 +1933,50 @@ public class AdminPanelButtonHandler extends ListenerAdapter {
             .setDefaultValues(List.of(state.action))
             .build();
 
-    StringSelectMenu.Builder optionSelectBuilder =
-        StringSelectMenu.create(SELECT_ESCORT_PRICING_PANEL_OPTION).setPlaceholder("選擇護航選項");
-    optionMap
-        .values()
-        .forEach(
-            view ->
-                optionSelectBuilder.addOption(
-                    truncate(view.optionCode() + "｜" + view.option().target(), 100),
-                    view.optionCode(),
-                    truncate(
-                        String.format(
-                            "%s｜%s｜NT$%,d",
-                            view.option().type(), view.option().level(), view.effectivePriceTwd()),
-                        100)));
-    if (!optionMap.isEmpty()
-        && state.optionCode != null
-        && optionMap.containsKey(state.optionCode)) {
-      optionSelectBuilder.setDefaultValues(List.of(state.optionCode));
+    List<EscortOptionPricingService.OptionPriceView> allOptions =
+        new java.util.ArrayList<>(optionMap.values());
+    int primaryLimit = Math.min(25, allOptions.size());
+    List<EscortOptionPricingService.OptionPriceView> primaryOptions =
+        allOptions.subList(0, primaryLimit);
+    List<EscortOptionPricingService.OptionPriceView> extraOptions =
+        allOptions.size() > primaryLimit
+            ? allOptions.subList(primaryLimit, allOptions.size())
+            : List.of();
+
+    String selectedCode =
+        state.optionCode != null && optionMap.containsKey(state.optionCode)
+            ? state.optionCode
+            : null;
+    boolean selectedInPrimary = false;
+    boolean selectedInExtra = false;
+    if (selectedCode != null) {
+      selectedInPrimary =
+          primaryOptions.stream().anyMatch(option -> option.optionCode().equals(selectedCode));
+      if (!selectedInPrimary) {
+        selectedInExtra =
+            extraOptions.stream().anyMatch(option -> option.optionCode().equals(selectedCode));
+      }
     }
-    StringSelectMenu optionSelect = optionSelectBuilder.build();
+
+    StringSelectMenu.Builder optionPrimaryBuilder =
+        StringSelectMenu.create(SELECT_ESCORT_PRICING_PANEL_OPTION).setPlaceholder("選擇護航選項");
+    primaryOptions.forEach(view -> addEscortPricingOption(optionPrimaryBuilder, view));
+    if (selectedInPrimary) {
+      optionPrimaryBuilder.setDefaultValues(List.of(selectedCode));
+    }
+    StringSelectMenu optionPrimary = optionPrimaryBuilder.build();
+
+    StringSelectMenu optionExtra = null;
+    if (!extraOptions.isEmpty()) {
+      StringSelectMenu.Builder optionExtraBuilder =
+          StringSelectMenu.create(SELECT_ESCORT_PRICING_PANEL_OPTION_EXTRA)
+              .setPlaceholder("選擇護航選項（更多）");
+      extraOptions.forEach(view -> addEscortPricingOption(optionExtraBuilder, view));
+      if (selectedInExtra) {
+        optionExtraBuilder.setDefaultValues(List.of(selectedCode));
+      }
+      optionExtra = optionExtraBuilder.build();
+    }
 
     boolean canConfirm =
         state.optionCode != null
@@ -1962,13 +1990,30 @@ public class AdminPanelButtonHandler extends ListenerAdapter {
             ? Button.success(BUTTON_ESCORT_PRICING_PANEL_CONFIRM, "✅ 確認送出")
             : Button.success(BUTTON_ESCORT_PRICING_PANEL_CONFIRM, "✅ 確認送出").asDisabled();
 
-    return List.of(
-        ActionRow.of(actionSelect),
-        ActionRow.of(optionSelect),
+    List<ActionRow> rows = new java.util.ArrayList<>();
+    rows.add(ActionRow.of(actionSelect));
+    rows.add(ActionRow.of(optionPrimary));
+    if (optionExtra != null) {
+      rows.add(ActionRow.of(optionExtra));
+    }
+    rows.add(
         ActionRow.of(
             inputPriceBtn,
             confirmBtn,
             Button.secondary(BUTTON_ESCORT_PRICING_PANEL_CLOSE, "✖ 關閉")));
+    return rows;
+  }
+
+  private void addEscortPricingOption(
+      StringSelectMenu.Builder optionBuilder, EscortOptionPricingService.OptionPriceView view) {
+    optionBuilder.addOption(
+        truncate(view.optionCode() + "｜" + view.option().target(), 100),
+        view.optionCode(),
+        truncate(
+            String.format(
+                "%s｜%s｜NT$%,d",
+                view.option().type(), view.option().level(), view.effectivePriceTwd()),
+            100));
   }
 
   private Map<String, EscortOptionPricingService.OptionPriceView> toEscortOptionMap(

--- a/src/test/java/ltdjms/discord/panel/commands/AdminPanelButtonHandlerTest.java
+++ b/src/test/java/ltdjms/discord/panel/commands/AdminPanelButtonHandlerTest.java
@@ -8,8 +8,12 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.DisplayName;
@@ -29,6 +33,7 @@ import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.dv8tion.jda.api.interactions.InteractionHook;
 import net.dv8tion.jda.api.interactions.components.ActionRow;
 import net.dv8tion.jda.api.interactions.components.buttons.Button;
+import net.dv8tion.jda.api.interactions.components.selections.StringSelectMenu;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 
 class AdminPanelButtonHandlerTest {
@@ -189,11 +194,72 @@ class AdminPanelButtonHandlerTest {
     verify(event, never()).replyModal(any());
   }
 
+  @Test
+  @DisplayName("護航定價面板超過 25 個選項時應分拆為兩個選單")
+  void escortPricingPanelShouldSplitMenusWhenOptionsExceedLimit() throws Exception {
+    List<EscortOptionPricingService.OptionPriceView> optionPrices =
+        EscortOrderOptionCatalog.allOptions().stream()
+            .map(
+                option ->
+                    new EscortOptionPricingService.OptionPriceView(
+                        option.code(), option, option.priceTwd(), option.priceTwd(), false))
+            .toList();
+    String selectedCode = optionPrices.get(optionPrices.size() - 1).optionCode();
+    Map<String, EscortOptionPricingService.OptionPriceView> optionMap =
+        optionPrices.stream()
+            .collect(
+                Collectors.toMap(
+                    EscortOptionPricingService.OptionPriceView::optionCode,
+                    view -> view,
+                    (left, right) -> left,
+                    LinkedHashMap::new));
+
+    Class<?> stateClass =
+        Class.forName(AdminPanelButtonHandler.class.getName() + "$EscortPricingPanelState");
+    Constructor<?> stateConstructor = stateClass.getDeclaredConstructor();
+    stateConstructor.setAccessible(true);
+    Object state = stateConstructor.newInstance();
+
+    Field optionCodeField = stateClass.getDeclaredField("optionCode");
+    optionCodeField.setAccessible(true);
+    optionCodeField.set(state, selectedCode);
+
+    Method method =
+        AdminPanelButtonHandler.class.getDeclaredMethod(
+            "buildEscortPricingPanelComponents", stateClass, Map.class);
+    method.setAccessible(true);
+
+    @SuppressWarnings("unchecked")
+    List<ActionRow> rows = (List<ActionRow>) method.invoke(handler, state, optionMap);
+
+    StringSelectMenu primaryMenu =
+        findSelectMenu(rows, AdminPanelButtonHandler.SELECT_ESCORT_PRICING_PANEL_OPTION);
+    StringSelectMenu extraMenu =
+        findSelectMenu(rows, AdminPanelButtonHandler.SELECT_ESCORT_PRICING_PANEL_OPTION_EXTRA);
+
+    assertThat(primaryMenu).isNotNull();
+    assertThat(extraMenu).isNotNull();
+    assertThat(primaryMenu.getOptions()).hasSize(25);
+    assertThat(extraMenu.getOptions()).hasSize(optionPrices.size() - 25);
+    assertThat(extraMenu.getOptions())
+        .anyMatch(option -> selectedCode.equals(option.getValue()) && option.isDefault());
+  }
+
   private List<String> flattenButtonIds(List<ActionRow> rows) {
     return rows.stream()
         .flatMap(row -> row.getComponents().stream())
         .map(component -> (Button) component)
         .map(Button::getId)
         .collect(Collectors.toList());
+  }
+
+  private StringSelectMenu findSelectMenu(List<ActionRow> rows, String menuId) {
+    return rows.stream()
+        .flatMap(row -> row.getComponents().stream())
+        .filter(component -> component instanceof StringSelectMenu)
+        .map(component -> (StringSelectMenu) component)
+        .filter(menu -> menuId.equals(menu.getId()))
+        .findFirst()
+        .orElse(null);
   }
 }


### PR DESCRIPTION
## Related Issues / Motivation
- Closes #35
- Closes #36
- The bot failed to initialize file appenders in Docker due to host bind-mount permissions.
- The escort pricing edit panel crashed when option count exceeded Discord/JDA's 25-option select menu limit.

## Engineering Decisions and Rationale
- Switched bot log storage from host bind mount (`./logs`) to a Docker named volume (`bot_logs`) in `docker-compose.yml`.
- This keeps persistent logs while avoiding host UID/GID and permission mismatches against the non-root `botuser` runtime.
- Split escort pricing option rendering into primary and extra select menus in `AdminPanelButtonHandler`.
- Added a dedicated extra select ID and routed both menus to the same option-selection handler so state updates stay consistent.
- Extracted menu option-building logic into a helper to keep behavior consistent across both menus.
- Added a regression test that builds the panel with the full escort catalog and asserts options are split across two menus with default selection preserved.

## Test Results and Commands
- ✅ `mvn -Dtest=AdminPanelButtonHandlerTest test`
- ✅ `mvn spotless:check`
- ✅ `docker compose config`
- ✅ `docker compose run --rm --no-deps bot` (no `/app/logs/* Permission denied`; process exits later due missing DB in isolated validation run)

### Test Cases (for complex changes)
- Escort pricing panel with >25 options should render multiple select menus without throwing `IllegalArgumentException`.
- Selected option in overflow range should remain default-selected in the extra menu.
- Docker bot startup should initialize APP/WARN/ERROR file appenders without `/app/logs` permission errors under compose-managed volume.
