### PR TITLE
fix: harden paid ECPay callback validation

### DIFF
--- a/src/main/java/ltdjms/discord/shop/services/FiatPaymentCallbackService.java
+++ b/src/main/java/ltdjms/discord/shop/services/FiatPaymentCallbackService.java
@@ -114,6 +114,15 @@ public class FiatPaymentCallbackService {
         return CallbackResult.ok();
       }
 
+      if (paid && !isValidPaidCallback(callbackNode, order, orderNumber)) {
+        fiatOrderRepository.updateCallbackStatus(
+            orderNumber, tradeStatus, paymentMessage, callbackPayload);
+        LOG.warn(
+            "ECPay callback rejected paid transition due to validation failure: orderNumber={}",
+            orderNumber);
+        return CallbackResult.ok();
+      }
+
       FiatOrder paidOrder =
           fiatOrderRepository
               .markPaidIfPending(
@@ -301,6 +310,60 @@ public class FiatPaymentCallbackService {
     return textOrNull(callbackNode.path("TradeMsg").asText(null));
   }
 
+  private String extractMerchantId(JsonNode callbackNode) {
+    String direct = textOrNull(callbackNode.path("MerchantID").asText(null));
+    if (direct != null) {
+      return direct;
+    }
+    return textOrNull(callbackNode.path("OrderInfo").path("MerchantID").asText(null));
+  }
+
+  private Long extractTradeAmount(JsonNode callbackNode) {
+    Long direct = parsePositiveLong(callbackNode.path("TradeAmt").asText(null));
+    if (direct != null) {
+      return direct;
+    }
+    Long nestedTradeAmt =
+        parsePositiveLong(callbackNode.path("OrderInfo").path("TradeAmt").asText(null));
+    if (nestedTradeAmt != null) {
+      return nestedTradeAmt;
+    }
+    return parsePositiveLong(callbackNode.path("OrderInfo").path("TotalAmount").asText(null));
+  }
+
+  private boolean isValidPaidCallback(JsonNode callbackNode, FiatOrder order, String orderNumber) {
+    String expectedMerchantId = textOrNull(config.getEcpayMerchantId());
+    if (expectedMerchantId != null) {
+      String callbackMerchantId = extractMerchantId(callbackNode);
+      if (!expectedMerchantId.equals(callbackMerchantId)) {
+        LOG.warn(
+            "ECPay callback merchant mismatch: orderNumber={}, expectedMerchantId={},"
+                + " callbackMerchantId={}",
+            orderNumber,
+            expectedMerchantId,
+            callbackMerchantId);
+        return false;
+      }
+    }
+
+    Long callbackAmount = extractTradeAmount(callbackNode);
+    if (callbackAmount == null) {
+      LOG.warn(
+          "ECPay callback missing valid TradeAmt for paid status: orderNumber={}", orderNumber);
+      return false;
+    }
+    if (callbackAmount.longValue() != order.amountTwd()) {
+      LOG.warn(
+          "ECPay callback amount mismatch: orderNumber={}, expectedAmount={}, callbackAmount={}",
+          orderNumber,
+          order.amountTwd(),
+          callbackAmount);
+      return false;
+    }
+
+    return true;
+  }
+
   private boolean isPaidStatus(String tradeStatus) {
     return "1".equals(tradeStatus);
   }
@@ -320,6 +383,19 @@ public class FiatPaymentCallbackService {
       return null;
     }
     return value.trim();
+  }
+
+  private Long parsePositiveLong(String value) {
+    String text = textOrNull(value);
+    if (text == null) {
+      return null;
+    }
+    try {
+      long parsed = Long.parseLong(text);
+      return parsed > 0 ? parsed : null;
+    } catch (NumberFormatException e) {
+      return null;
+    }
   }
 
   public record CallbackResult(int httpStatus, String responseBody) {

--- a/src/test/java/ltdjms/discord/shop/services/FiatPaymentCallbackServiceTest.java
+++ b/src/test/java/ltdjms/discord/shop/services/FiatPaymentCallbackServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -43,6 +44,7 @@ import ltdjms.discord.shop.domain.FiatOrderRepository;
 class FiatPaymentCallbackServiceTest {
 
   private static final String ORDER_NUMBER = "FD260304000001";
+  private static final String MERCHANT_ID = "2000132";
   private static final String HASH_KEY = "1234567890123456";
   private static final String HASH_IV = "6543210987654321";
   private static final long GUILD_ID = 123L;
@@ -61,6 +63,7 @@ class FiatPaymentCallbackServiceTest {
   @BeforeEach
   void setUp() {
     fixedClock = Clock.fixed(Instant.parse("2026-03-04T12:00:00Z"), ZoneOffset.UTC);
+    lenient().when(config.getEcpayMerchantId()).thenReturn(MERCHANT_ID);
     when(config.getEcpayHashKey()).thenReturn(HASH_KEY);
     when(config.getEcpayHashIv()).thenReturn(HASH_IV);
     service =
@@ -113,7 +116,7 @@ class FiatPaymentCallbackServiceTest {
         service.handleCallback(
             encryptedPayload(
                 """
-                {"MerchantTradeNo":"FD260304000001","TradeStatus":"1","RtnCode":1,"RtnMsg":"付款成功"}
+                {"MerchantID":"2000132","MerchantTradeNo":"FD260304000001","TradeAmt":"1200","TradeStatus":"1","RtnCode":1,"RtnMsg":"付款成功"}
                 """),
             "application/json");
 
@@ -142,7 +145,7 @@ class FiatPaymentCallbackServiceTest {
         service.handleCallback(
             encryptedPayload(
                 """
-                {"MerchantTradeNo":"FD260304000001","TradeStatus":"1","RtnCode":1,"RtnMsg":"付款成功"}
+                {"MerchantID":"2000132","MerchantTradeNo":"FD260304000001","TradeAmt":"1200","TradeStatus":"1","RtnCode":1,"RtnMsg":"付款成功"}
                 """),
             "application/json");
 
@@ -259,7 +262,7 @@ class FiatPaymentCallbackServiceTest {
         service.handleCallback(
             encryptedPayload(
                 """
-                {"MerchantTradeNo":"FD260304000001","TradeStatus":"1","RtnCode":1,"RtnMsg":"付款成功"}
+                {"MerchantID":"2000132","MerchantTradeNo":"FD260304000001","TradeAmt":"1200","TradeStatus":"1","RtnCode":1,"RtnMsg":"付款成功"}
                 """),
             "application/json");
 
@@ -296,6 +299,50 @@ class FiatPaymentCallbackServiceTest {
 
     assertThat(result.httpStatus()).isEqualTo(400);
     verify(fiatOrderRepository, never()).findByOrderNumber(any());
+  }
+
+  @Test
+  @DisplayName("付款金額不一致時不應標記訂單已付款")
+  void shouldRejectPaidCallbackWhenTradeAmountMismatch() {
+    when(fiatOrderRepository.findByOrderNumber(ORDER_NUMBER))
+        .thenReturn(Optional.of(pendingOrder()));
+    when(fiatOrderRepository.updateCallbackStatus(eq(ORDER_NUMBER), eq("1"), eq("付款成功"), any()))
+        .thenReturn(Optional.of(pendingOrder()));
+
+    FiatPaymentCallbackService.CallbackResult result =
+        service.handleCallback(
+            encryptedPayload(
+                """
+                {"MerchantID":"2000132","MerchantTradeNo":"FD260304000001","TradeAmt":"1","TradeStatus":"1","RtnCode":1,"RtnMsg":"付款成功"}
+                """),
+            "application/json");
+
+    assertThat(result.httpStatus()).isEqualTo(200);
+    verify(fiatOrderRepository, never())
+        .markPaidIfPending(any(), any(), any(), any(), any(Instant.class));
+    verify(fiatOrderRepository).updateCallbackStatus(eq(ORDER_NUMBER), eq("1"), eq("付款成功"), any());
+  }
+
+  @Test
+  @DisplayName("MerchantID 不一致時不應標記訂單已付款")
+  void shouldRejectPaidCallbackWhenMerchantMismatch() {
+    when(fiatOrderRepository.findByOrderNumber(ORDER_NUMBER))
+        .thenReturn(Optional.of(pendingOrder()));
+    when(fiatOrderRepository.updateCallbackStatus(eq(ORDER_NUMBER), eq("1"), eq("付款成功"), any()))
+        .thenReturn(Optional.of(pendingOrder()));
+
+    FiatPaymentCallbackService.CallbackResult result =
+        service.handleCallback(
+            encryptedPayload(
+                """
+                {"MerchantID":"9999999","MerchantTradeNo":"FD260304000001","TradeAmt":"1200","TradeStatus":"1","RtnCode":1,"RtnMsg":"付款成功"}
+                """),
+            "application/json");
+
+    assertThat(result.httpStatus()).isEqualTo(200);
+    verify(fiatOrderRepository, never())
+        .markPaidIfPending(any(), any(), any(), any(), any(Instant.class));
+    verify(fiatOrderRepository).updateCallbackStatus(eq(ORDER_NUMBER), eq("1"), eq("付款成功"), any());
   }
 
   private FiatOrder pendingOrder() {


### PR DESCRIPTION
## Summary
- harden `FiatPaymentCallbackService` to validate paid callback integrity before state transition
- require paid callbacks to match configured `MerchantID` (when configured)
- require paid callbacks to include a positive trade amount matching `fiat_order.amount_twd`
- reject invalid paid transitions by recording callback status only (no paid/fulfillment transition)
- add security regression tests for amount mismatch and merchant mismatch cases

## Why
The previous flow trusted `TradeStatus=1` + `MerchantTradeNo` without amount/merchant consistency checks, which could allow unsafe paid transitions under forged/tampered callback payloads.

## Validation
- `mvn -q -Dtest=FiatPaymentCallbackServiceTest test`
- pre-commit hook compile/type-check (`mvn test-compile`) passed during commit
