### PR TITLE
fix: avoid blank Discord message on empty agent response

### DIFF
--- a/src/main/java/ltdjms/discord/aiagent/commands/AgentCompletionListener.java
+++ b/src/main/java/ltdjms/discord/aiagent/commands/AgentCompletionListener.java
@@ -24,6 +24,7 @@ import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 public final class AgentCompletionListener implements Consumer<DomainEvent> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AgentCompletionListener.class);
+  private static final String EMPTY_RESPONSE_FALLBACK = ":question: AI 沒有產生回應";
 
   @Inject
   public AgentCompletionListener() {
@@ -53,8 +54,16 @@ public final class AgentCompletionListener implements Consumer<DomainEvent> {
       }
 
       List<String> messages = MessageSplitter.split(event.finalResponse());
+      boolean sentAnyMessage = false;
       for (String message : messages) {
+        if (message == null || message.isBlank()) {
+          continue;
+        }
         channel.sendMessage(message).queue();
+        sentAnyMessage = true;
+      }
+      if (!sentAnyMessage) {
+        channel.sendMessage(EMPTY_RESPONSE_FALLBACK).queue();
       }
 
       LOGGER.info(

--- a/src/test/java/ltdjms/discord/aiagent/commands/AgentCompletionListenerTest.java
+++ b/src/test/java/ltdjms/discord/aiagent/commands/AgentCompletionListenerTest.java
@@ -175,6 +175,25 @@ class AgentCompletionListenerTest {
       // Then
       verify(threadChannel, never()).sendMessage(any(CharSequence.class));
     }
+
+    @Test
+    @DisplayName("should send fallback when final response is blank")
+    void shouldSendFallbackWhenFinalResponseIsBlank() {
+      // Given
+      when(jda.getGuildById(123L)).thenReturn(guild);
+      when(guild.getThreadChannelById(456L)).thenReturn(threadChannel);
+
+      AgentCompletedEvent event =
+          new AgentCompletedEvent(
+              123L, "456", "789", "conv-123", "   \n\t  ", List.of(), Instant.now());
+
+      // When
+      listener.accept(event);
+
+      // Then
+      verify(threadChannel).sendMessage(":question: AI 沒有產生回應");
+      verify(threadChannel, never()).sendMessage("   \n\t  ");
+    }
   }
 
   @Nested


### PR DESCRIPTION
## Summary
- add edge-case handling in `AgentCompletionListener` for blank/whitespace final responses
- skip blank chunks after `MessageSplitter.split(...)`
- send `:question: AI 沒有產生回應` fallback when no non-blank chunk exists

## Edge Case
- Agent final response contains only whitespace (e.g. spaces/newlines/tabs)

## Tests
- `mvn -q -Dtest=AgentCompletionListenerTest test`
- `mvn -q -Dtest=ToolExecutionListenerTest test`

## Risk Notes
- Minimal behavior change, only affects blank final responses.
- Normal non-empty responses are unchanged.
