### PR TITLE
fix: enforce Discord page length in markdown code-block pagination

### DIFF
--- a/src/main/java/ltdjms/discord/markdown/services/DiscordMarkdownPaginator.java
+++ b/src/main/java/ltdjms/discord/markdown/services/DiscordMarkdownPaginator.java
@@ -53,7 +53,8 @@ public final class DiscordMarkdownPaginator {
 
       String remaining = lineWithNewline;
       while (!remaining.isEmpty()) {
-        int available = MAX_MESSAGE_LENGTH - current.length();
+        int available =
+            MAX_MESSAGE_LENGTH - current.length() - reservedCharsForCodeFence(current, inCodeBlock);
         if (available <= 0) {
           current = flushPage(pages, current, inCodeBlock, codeFence, true);
           continue;
@@ -113,5 +114,12 @@ public final class DiscordMarkdownPaginator {
     if (builder.charAt(length - 1) != '\n') {
       builder.append("\n");
     }
+  }
+
+  private int reservedCharsForCodeFence(StringBuilder current, boolean inCodeBlock) {
+    if (!inCodeBlock) {
+      return 0;
+    }
+    return 4;
   }
 }

--- a/src/test/java/ltdjms/discord/markdown/unit/services/DiscordMarkdownPaginatorTest.java
+++ b/src/test/java/ltdjms/discord/markdown/unit/services/DiscordMarkdownPaginatorTest.java
@@ -1,0 +1,26 @@
+package ltdjms.discord.markdown.unit.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import ltdjms.discord.markdown.services.DiscordMarkdownPaginator;
+
+@DisplayName("DiscordMarkdownPaginator")
+class DiscordMarkdownPaginatorTest {
+
+  @Test
+  @DisplayName("長程式碼區塊分頁後每頁都不應超過 Discord 長度上限")
+  void longCodeBlock_shouldKeepEveryPageWithinLimit() {
+    DiscordMarkdownPaginator paginator = new DiscordMarkdownPaginator();
+    String content = "```java\n" + "a".repeat(6000) + "\n```";
+
+    List<String> pages = paginator.paginate(content);
+
+    assertThat(pages).isNotEmpty();
+    assertThat(pages).allSatisfy(page -> assertThat(page.length()).isLessThanOrEqualTo(1900));
+  }
+}


### PR DESCRIPTION
## Summary\n- reproduce and fix an edge case where long markdown code blocks could produce pages longer than Discord's 1900-char cap\n- reserve closing code-fence space during line chunking while inside code blocks\n- add regression test to ensure every paginated page stays within length limit\n\n## Edge case\n- input: a single very long fenced code block (java ... )\n- before: some pages reached 1901-1904 chars because appended closing fence overflowed\n- after: all pages are capped at 1900 chars\n\n## Tests\n- \n- 09:03:28,064 |-INFO in ch.qos.logback.classic.LoggerContext[default] - This is logback-classic version 1.5.12
09:03:28,065 |-INFO in ch.qos.logback.classic.util.ContextInitializer@749d7c01 - No custom configurators were discovered as a service.
09:03:28,065 |-INFO in ch.qos.logback.classic.util.ContextInitializer@749d7c01 - Trying to configure with ch.qos.logback.classic.joran.SerializedModelConfigurator
09:03:28,065 |-INFO in ch.qos.logback.classic.util.ContextInitializer@749d7c01 - Constructed configurator of type class ch.qos.logback.classic.joran.SerializedModelConfigurator
09:03:28,066 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback-test.scmo]
09:03:28,066 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback.scmo]
09:03:28,067 |-INFO in ch.qos.logback.classic.util.ContextInitializer@749d7c01 - ch.qos.logback.classic.joran.SerializedModelConfigurator.configure() call lasted 1 milliseconds. ExecutionStatus=INVOKE_NEXT_IF_ANY
09:03:28,067 |-INFO in ch.qos.logback.classic.util.ContextInitializer@749d7c01 - Trying to configure with ch.qos.logback.classic.util.DefaultJoranConfigurator
09:03:28,067 |-INFO in ch.qos.logback.classic.util.ContextInitializer@749d7c01 - Constructed configurator of type class ch.qos.logback.classic.util.DefaultJoranConfigurator
09:03:28,067 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback-test.xml]
09:03:28,067 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Found resource [logback.xml] at [file:/Users/tszkinlai/.codex/worktrees/aa5e/LTDJMS/target/classes/logback.xml]
09:03:28,140 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@1d3a03fe - value "logs" substituted for "${LOG_DIR:-logs}"
09:03:28,140 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@1d3a03fe - value "WARN" substituted for "${LOG_LEVEL:-WARN}"
09:03:28,140 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@1d3a03fe - value "INFO" substituted for "${APP_LOG_LEVEL:-INFO}"
09:03:28,140 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@1d3a03fe - value "20MB" substituted for "${LOG_MAX_FILE_SIZE:-20MB}"
09:03:28,140 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@1d3a03fe - value "30" substituted for "${LOG_MAX_HISTORY_DAYS:-30}"
09:03:28,140 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@1d3a03fe - value "3GB" substituted for "${LOG_TOTAL_SIZE_CAP:-3GB}"
09:03:28,142 |-INFO in ch.qos.logback.classic.model.processor.ConfigurationModelHandlerFull - Registering a new ReconfigureOnChangeTask ReconfigureOnChangeTask(born:1772845408142)
09:03:28,142 |-INFO in ch.qos.logback.classic.model.processor.ConfigurationModelHandlerFull - Will scan for changes in [ConfigurationWatchList(mainURL=file:/Users/tszkinlai/.codex/worktrees/aa5e/LTDJMS/target/classes/logback.xml, fileWatchList={/Users/tszkinlai/.codex/worktrees/aa5e/LTDJMS/target/classes/logback.xml}, urlWatchList=[})] 
09:03:28,143 |-INFO in ch.qos.logback.classic.model.processor.ConfigurationModelHandlerFull - Setting ReconfigureOnChangeTask scanning period to 30 seconds
09:03:28,145 |-INFO in ch.qos.logback.core.model.processor.AppenderModelHandler - Processing appender named [CONSOLE]
09:03:28,145 |-INFO in ch.qos.logback.core.model.processor.AppenderModelHandler - About to instantiate appender of type [ch.qos.logback.core.ConsoleAppender]
09:03:28,151 |-INFO in ch.qos.logback.core.model.processor.ImplicitModelHandler - Assuming default type [ch.qos.logback.classic.encoder.PatternLayoutEncoder] for [encoder] property
09:03:28,151 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@1d3a03fe - value "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n" substituted for "${LOG_PATTERN}"
09:03:28,176 |-WARN in ch.qos.logback.core.model.processor.AppenderModelHandler - Appender named [JSON_CONSOLE] not referenced. Skipping further processing.
09:03:28,176 |-INFO in ch.qos.logback.core.model.processor.AppenderModelHandler - Processing appender named [APP_FILE]
09:03:28,176 |-INFO in ch.qos.logback.core.model.processor.AppenderModelHandler - About to instantiate appender of type [ch.qos.logback.core.rolling.RollingFileAppender]
09:03:28,178 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@1d3a03fe - value "logs/app.log" substituted for "${LOG_DIR}/app.log"
09:03:28,181 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@1d3a03fe - value "logs/archive/app.%d{yyyy-MM-dd}.%i.log.gz" substituted for "${LOG_DIR}/archive/app.%d{yyyy-MM-dd}.%i.log.gz"
09:03:28,181 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@1d3a03fe - value "20MB" substituted for "${LOG_MAX_FILE_SIZE}"
09:03:28,181 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@1d3a03fe - value "30" substituted for "${LOG_MAX_HISTORY_DAYS}"
09:03:28,182 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@1d3a03fe - value "3GB" substituted for "${LOG_TOTAL_SIZE_CAP}"
09:03:28,182 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@256417920 - setting totalSizeCap to 3 GB
09:03:28,185 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@256417920 - Archive files will be limited to [20 MB] each.
09:03:28,187 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@256417920 - Will use gz compression
09:03:28,188 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@256417920 - Will use the pattern logs/archive/app.%d{yyyy-MM-dd}.%i.log for the active file
09:03:28,196 |-INFO in ch.qos.logback.core.rolling.SizeAndTimeBasedFileNamingAndTriggeringPolicy@5f7cd50e - The date pattern is 'yyyy-MM-dd' from file name pattern 'logs/archive/app.%d{yyyy-MM-dd}.%i.log.gz'.
09:03:28,196 |-INFO in ch.qos.logback.core.rolling.SizeAndTimeBasedFileNamingAndTriggeringPolicy@5f7cd50e - Roll-over at midnight.
09:03:28,199 |-INFO in ch.qos.logback.core.rolling.SizeAndTimeBasedFileNamingAndTriggeringPolicy@5f7cd50e - Setting initial period to 2026-03-07T01:02:07.709Z
09:03:28,201 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@256417920 - Cleaning on start up
09:03:28,201 |-INFO in c.q.l.core.rolling.helper.TimeBasedArchiveRemover - first clean up after appender initialization
09:03:28,201 |-INFO in c.q.l.core.rolling.helper.TimeBasedArchiveRemover - Multiple periods, i.e. 32 periods, seem to have elapsed. This is expected at application start.
09:03:28,201 |-INFO in ch.qos.logback.core.model.processor.ImplicitModelHandler - Assuming default type [ch.qos.logback.classic.encoder.PatternLayoutEncoder] for [encoder] property
09:03:28,201 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@1d3a03fe - value "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n" substituted for "${LOG_PATTERN}"
09:03:28,203 |-INFO in ch.qos.logback.core.rolling.RollingFileAppender[APP_FILE] - Active log file name: logs/app.log
09:03:28,203 |-INFO in ch.qos.logback.core.rolling.RollingFileAppender[APP_FILE] - Setting currentFileLength to 0 for logs/app.log
09:03:28,203 |-INFO in ch.qos.logback.core.rolling.RollingFileAppender[APP_FILE] - File property is set to [logs/app.log]
09:03:28,204 |-INFO in ch.qos.logback.core.model.processor.AppenderModelHandler - Processing appender named [WARN_FILE]
09:03:28,204 |-INFO in ch.qos.logback.core.model.processor.AppenderModelHandler - About to instantiate appender of type [ch.qos.logback.core.rolling.RollingFileAppender]
09:03:28,204 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@1d3a03fe - value "logs/warn.log" substituted for "${LOG_DIR}/warn.log"
09:03:28,204 |-INFO in c.q.l.core.rolling.helper.TimeBasedArchiveRemover - No removal attempts were made.
09:03:28,205 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@1d3a03fe - value "logs/archive/warn.%d{yyyy-MM-dd}.%i.log.gz" substituted for "${LOG_DIR}/archive/warn.%d{yyyy-MM-dd}.%i.log.gz"
09:03:28,205 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@1d3a03fe - value "20MB" substituted for "${LOG_MAX_FILE_SIZE}"
09:03:28,205 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@1d3a03fe - value "30" substituted for "${LOG_MAX_HISTORY_DAYS}"
09:03:28,205 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@1d3a03fe - value "3GB" substituted for "${LOG_TOTAL_SIZE_CAP}"
09:03:28,205 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@1075758996 - setting totalSizeCap to 3 GB
09:03:28,205 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@1075758996 - Archive files will be limited to [20 MB] each.
09:03:28,205 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@1075758996 - Will use gz compression
09:03:28,205 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@1075758996 - Will use the pattern logs/archive/warn.%d{yyyy-MM-dd}.%i.log for the active file
09:03:28,205 |-INFO in ch.qos.logback.core.rolling.SizeAndTimeBasedFileNamingAndTriggeringPolicy@d76099a - The date pattern is 'yyyy-MM-dd' from file name pattern 'logs/archive/warn.%d{yyyy-MM-dd}.%i.log.gz'.
09:03:28,205 |-INFO in ch.qos.logback.core.rolling.SizeAndTimeBasedFileNamingAndTriggeringPolicy@d76099a - Roll-over at midnight.
09:03:28,205 |-INFO in ch.qos.logback.core.rolling.SizeAndTimeBasedFileNamingAndTriggeringPolicy@d76099a - Setting initial period to 2026-03-07T01:02:07.711Z
09:03:28,205 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@1075758996 - Cleaning on start up
09:03:28,205 |-INFO in c.q.l.core.rolling.helper.TimeBasedArchiveRemover - first clean up after appender initialization
09:03:28,205 |-INFO in ch.qos.logback.core.model.processor.ImplicitModelHandler - Assuming default type [ch.qos.logback.classic.encoder.PatternLayoutEncoder] for [encoder] property
09:03:28,205 |-INFO in c.q.l.core.rolling.helper.TimeBasedArchiveRemover - Multiple periods, i.e. 32 periods, seem to have elapsed. This is expected at application start.
09:03:28,205 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@1d3a03fe - value "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n" substituted for "${LOG_PATTERN}"
09:03:28,205 |-INFO in ch.qos.logback.core.rolling.RollingFileAppender[WARN_FILE] - Active log file name: logs/warn.log
09:03:28,205 |-INFO in ch.qos.logback.core.rolling.RollingFileAppender[WARN_FILE] - Setting currentFileLength to 0 for logs/warn.log
09:03:28,205 |-INFO in ch.qos.logback.core.rolling.RollingFileAppender[WARN_FILE] - File property is set to [logs/warn.log]
09:03:28,206 |-INFO in ch.qos.logback.core.model.processor.AppenderModelHandler - Processing appender named [ERROR_FILE]
09:03:28,206 |-INFO in ch.qos.logback.core.model.processor.AppenderModelHandler - About to instantiate appender of type [ch.qos.logback.core.rolling.RollingFileAppender]
09:03:28,206 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@1d3a03fe - value "logs/error.log" substituted for "${LOG_DIR}/error.log"
09:03:28,206 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@1d3a03fe - value "logs/archive/error.%d{yyyy-MM-dd}.%i.log.gz" substituted for "${LOG_DIR}/archive/error.%d{yyyy-MM-dd}.%i.log.gz"
09:03:28,206 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@1d3a03fe - value "20MB" substituted for "${LOG_MAX_FILE_SIZE}"
09:03:28,206 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@1d3a03fe - value "30" substituted for "${LOG_MAX_HISTORY_DAYS}"
09:03:28,206 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@1d3a03fe - value "3GB" substituted for "${LOG_TOTAL_SIZE_CAP}"
09:03:28,206 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@1206973460 - setting totalSizeCap to 3 GB
09:03:28,206 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@1206973460 - Archive files will be limited to [20 MB] each.
09:03:28,206 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@1206973460 - Will use gz compression
09:03:28,207 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@1206973460 - Will use the pattern logs/archive/error.%d{yyyy-MM-dd}.%i.log for the active file
09:03:28,207 |-INFO in ch.qos.logback.core.rolling.SizeAndTimeBasedFileNamingAndTriggeringPolicy@7e1d8d41 - The date pattern is 'yyyy-MM-dd' from file name pattern 'logs/archive/error.%d{yyyy-MM-dd}.%i.log.gz'.
09:03:28,207 |-INFO in ch.qos.logback.core.rolling.SizeAndTimeBasedFileNamingAndTriggeringPolicy@7e1d8d41 - Roll-over at midnight.
09:03:28,207 |-INFO in ch.qos.logback.core.rolling.SizeAndTimeBasedFileNamingAndTriggeringPolicy@7e1d8d41 - Setting initial period to 2026-03-07T01:02:07.715Z
09:03:28,207 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@1206973460 - Cleaning on start up
09:03:28,207 |-INFO in ch.qos.logback.core.model.processor.ImplicitModelHandler - Assuming default type [ch.qos.logback.classic.encoder.PatternLayoutEncoder] for [encoder] property
09:03:28,207 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@1d3a03fe - value "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n" substituted for "${LOG_PATTERN}"
09:03:28,207 |-INFO in c.q.l.core.rolling.helper.TimeBasedArchiveRemover - first clean up after appender initialization
09:03:28,207 |-INFO in c.q.l.core.rolling.helper.TimeBasedArchiveRemover - Multiple periods, i.e. 32 periods, seem to have elapsed. This is expected at application start.
09:03:28,207 |-INFO in c.q.l.core.rolling.helper.TimeBasedArchiveRemover - No removal attempts were made.
09:03:28,207 |-INFO in ch.qos.logback.core.rolling.RollingFileAppender[ERROR_FILE] - Active log file name: logs/error.log
09:03:28,207 |-INFO in ch.qos.logback.core.rolling.RollingFileAppender[ERROR_FILE] - Setting currentFileLength to 0 for logs/error.log
09:03:28,207 |-INFO in ch.qos.logback.core.rolling.RollingFileAppender[ERROR_FILE] - File property is set to [logs/error.log]
09:03:28,207 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@1d3a03fe - value "INFO" substituted for "${APP_LOG_LEVEL}"
09:03:28,207 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [ltdjms.discord] to INFO
09:03:28,208 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [ltdjms.discord.currency.bot] to INFO
09:03:28,208 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [ltdjms.discord.currency.commands] to INFO
09:03:28,208 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [ltdjms.discord.currency.services] to INFO
09:03:28,208 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [ltdjms.discord.currency.persistence] to INFO
09:03:28,208 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [ltdjms.discord.discord] to INFO
09:03:28,208 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [ltdjms.discord.discord.adapter] to DEBUG
09:03:28,208 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [ltdjms.discord.aichat] to INFO
09:03:28,208 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [ltdjms.discord.aichat.commands] to INFO
09:03:28,208 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [ltdjms.discord.aichat.services] to INFO
09:03:28,208 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [net.dv8tion.jda] to INFO
09:03:28,208 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [net.dv8tion.jda.internal.requests] to WARN
09:03:28,208 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [net.dv8tion.jda.api.requests] to WARN
09:03:28,208 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [com.zaxxer.hikari] to INFO
09:03:28,208 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [com.zaxxer.hikari.pool] to INFO
09:03:28,208 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [org.postgresql] to WARN
09:03:28,208 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@1d3a03fe - value "WARN" substituted for "${LOG_LEVEL}"
09:03:28,208 |-INFO in ch.qos.logback.classic.model.processor.RootLoggerModelHandler - Setting level of ROOT logger to WARN
09:03:28,208 |-INFO in ch.qos.logback.core.model.processor.AppenderRefModelHandler - Attaching appender named [CONSOLE] to Logger[ROOT]
09:03:28,208 |-INFO in ch.qos.logback.core.model.processor.AppenderRefModelHandler - Attaching appender named [APP_FILE] to Logger[ROOT]
09:03:28,208 |-INFO in ch.qos.logback.core.model.processor.AppenderRefModelHandler - Attaching appender named [WARN_FILE] to Logger[ROOT]
09:03:28,208 |-INFO in ch.qos.logback.core.model.processor.AppenderRefModelHandler - Attaching appender named [ERROR_FILE] to Logger[ROOT]
09:03:28,208 |-INFO in ch.qos.logback.core.model.processor.DefaultProcessor@4809c771 - End of configuration.
09:03:28,208 |-INFO in c.q.l.core.rolling.helper.TimeBasedArchiveRemover - No removal attempts were made.
09:03:28,209 |-INFO in ch.qos.logback.classic.joran.JoranConfigurator@750e2d33 - Registering current configuration as safe fallback point
09:03:28,209 |-INFO in ch.qos.logback.classic.util.ContextInitializer@749d7c01 - ch.qos.logback.classic.util.DefaultJoranConfigurator.configure() call lasted 142 milliseconds. ExecutionStatus=DO_NOT_INVOKE_NEXT_IF_ANY