### PR TITLE
fix: fallback thread chat memory when JDA is not initialized

### DIFF
--- a/src/main/java/ltdjms/discord/aiagent/services/SimplifiedChatMemoryProvider.java
+++ b/src/main/java/ltdjms/discord/aiagent/services/SimplifiedChatMemoryProvider.java
@@ -103,9 +103,17 @@ public final class SimplifiedChatMemoryProvider implements ChatMemoryProvider {
 
     LOG.debug("Thread 級別會話: guildId={}, threadId={}, userId={}", guildId, threadId, userId);
 
+    long botUserId;
+    try {
+      botUserId = getBotUserId();
+    } catch (IllegalStateException e) {
+      LOG.warn("JDA 尚未初始化，Thread 會話改用空記憶體: {}", conversationId);
+      return createNonThreadMemory(conversationId);
+    }
+
     // 獲取 Discord Thread 歷史
     List<ChatMessage> threadMessages =
-        threadHistoryProvider.getThreadHistory(guildId, threadId, userId, getBotUserId());
+        threadHistoryProvider.getThreadHistory(guildId, threadId, userId, botUserId);
 
     LOG.debug("從 Discord Thread 獲取 {} 則訊息", threadMessages.size());
 

--- a/src/test/java/ltdjms/discord/aiagent/unit/services/SimplifiedChatMemoryProviderTest.java
+++ b/src/test/java/ltdjms/discord/aiagent/unit/services/SimplifiedChatMemoryProviderTest.java
@@ -82,4 +82,15 @@ class SimplifiedChatMemoryProviderTest {
     verify(threadHistoryProvider).getThreadHistory(100L, 200L, 300L, 900L);
     verify(toolCallHistory).getToolCallMessages(200L, 300L);
   }
+
+  @Test
+  @DisplayName("當 JDA 尚未初始化時 Thread 會話應回退為非 Thread 記憶體")
+  void shouldFallbackToNonThreadMemoryWhenJdaIsNotInitialized() {
+    var memory = provider.get("100:200:300");
+
+    assertThat(memory).isNotNull();
+    verify(threadHistoryProvider, never())
+        .getThreadHistory(anyLong(), anyLong(), anyLong(), anyLong());
+    verify(toolCallHistory, never()).getToolCallMessages(anyLong(), anyLong());
+  }
 }


### PR DESCRIPTION
## Summary
- harden `SimplifiedChatMemoryProvider` for thread-level conversation IDs when `JDAProvider` is not initialized yet
- fallback to non-thread memory instead of throwing `IllegalStateException`
- add regression test covering `100:200:300` conversation with missing JDA

## Edge case
- Thread-level memory request arrives before JDA bootstrap finishes
- previous behavior: throws and breaks message handling path
- new behavior: graceful fallback to short non-thread memory window

## Tests
- `mvn -q -Dtest=SimplifiedChatMemoryProviderTest test`
- `mvn -q -Dtest=DiscordThreadHistoryProviderTest test`
