### PR TITLE
fix: block decimal/hex IP literal SSRF bypass in fulfillment URLs

### DIFF
--- a/src/main/java/ltdjms/discord/product/services/ProductService.java
+++ b/src/main/java/ltdjms/discord/product/services/ProductService.java
@@ -425,11 +425,42 @@ public class ProductService {
     if (host.contains(":")) {
       return true;
     }
+    if (isDecimalIpv4Literal(host) || isHexIpv4Literal(host)) {
+      return true;
+    }
     if (!host.contains(".")) {
       return false;
     }
     for (char ch : host.toCharArray()) {
       if (!Character.isDigit(ch) && ch != '.') {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private boolean isDecimalIpv4Literal(String host) {
+    if (host == null || host.isBlank()) {
+      return false;
+    }
+    for (char ch : host.toCharArray()) {
+      if (!Character.isDigit(ch)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private boolean isHexIpv4Literal(String host) {
+    if (host == null || host.length() <= 2) {
+      return false;
+    }
+    if (!(host.startsWith("0x") || host.startsWith("0X"))) {
+      return false;
+    }
+    for (int i = 2; i < host.length(); i++) {
+      char ch = host.charAt(i);
+      if (!((ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f') || (ch >= 'A' && ch <= 'F'))) {
         return false;
       }
     }

--- a/src/main/java/ltdjms/discord/shop/services/ProductFulfillmentApiService.java
+++ b/src/main/java/ltdjms/discord/shop/services/ProductFulfillmentApiService.java
@@ -235,11 +235,42 @@ public class ProductFulfillmentApiService {
     if (host.contains(":")) {
       return true;
     }
+    if (isDecimalIpv4Literal(host) || isHexIpv4Literal(host)) {
+      return true;
+    }
     if (!host.contains(".")) {
       return false;
     }
     for (char ch : host.toCharArray()) {
       if (!Character.isDigit(ch) && ch != '.') {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private boolean isDecimalIpv4Literal(String host) {
+    if (host == null || host.isBlank()) {
+      return false;
+    }
+    for (char ch : host.toCharArray()) {
+      if (!Character.isDigit(ch)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private boolean isHexIpv4Literal(String host) {
+    if (host == null || host.length() <= 2) {
+      return false;
+    }
+    if (!(host.startsWith("0x") || host.startsWith("0X"))) {
+      return false;
+    }
+    for (int i = 2; i < host.length(); i++) {
+      char ch = host.charAt(i);
+      if (!((ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f') || (ch >= 'A' && ch <= 'F'))) {
         return false;
       }
     }

--- a/src/test/java/ltdjms/discord/product/services/ProductServiceTest.java
+++ b/src/test/java/ltdjms/discord/product/services/ProductServiceTest.java
@@ -300,6 +300,29 @@ class ProductServiceTest {
     }
 
     @Test
+    @DisplayName("should reject decimal IPv4 host that resolves to loopback")
+    void shouldRejectDecimalIpv4LoopbackHost() {
+      when(productRepository.existsByGuildIdAndName(TEST_GUILD_ID, "Unsafe Decimal Host"))
+          .thenReturn(false);
+
+      Result<Product, DomainError> result =
+          productService.createProduct(
+              TEST_GUILD_ID,
+              "Unsafe Decimal Host",
+              "desc",
+              null,
+              null,
+              300L,
+              null,
+              "http://2130706433/internal",
+              false,
+              null);
+
+      assertThat(result.isErr()).isTrue();
+      assertThat(result.getError().message()).contains("localhost 或內網位址");
+    }
+
+    @Test
     @DisplayName("should handle persistence failure on create")
     void shouldHandlePersistenceFailureOnCreate() {
       // Given

--- a/src/test/java/ltdjms/discord/shop/services/ProductFulfillmentApiServiceTest.java
+++ b/src/test/java/ltdjms/discord/shop/services/ProductFulfillmentApiServiceTest.java
@@ -238,4 +238,38 @@ class ProductFulfillmentApiServiceTest {
     assertThat(result.getError().message()).contains("localhost 或內網位址");
     verify(httpClient, never()).send(any(), anyStringBodyHandler());
   }
+
+  @Test
+  @DisplayName("應拒絕十進位 IPv4 主機（可解析成 loopback）避免繞過 SSRF 防護")
+  void shouldRejectDecimalIpv4LoopbackTargetAtRuntime() throws Exception {
+    Product product =
+        new Product(
+            1L,
+            GUILD_ID,
+            "Unsafe Decimal Host",
+            null,
+            Product.RewardType.CURRENCY,
+            100L,
+            200L,
+            null,
+            "http://2130706433/internal",
+            false,
+            null,
+            Instant.now(),
+            Instant.now());
+
+    Result<ltdjms.discord.shared.Unit, DomainError> result =
+        service.notifyFulfillment(
+            new ProductFulfillmentApiService.FulfillmentRequest(
+                GUILD_ID,
+                USER_ID,
+                product,
+                ProductFulfillmentApiService.PurchaseSource.CURRENCY_PURCHASE,
+                null,
+                null));
+
+    assertThat(result.isErr()).isTrue();
+    assertThat(result.getError().message()).contains("localhost 或內網位址");
+    verify(httpClient, never()).send(any(), anyStringBodyHandler());
+  }
 }


### PR DESCRIPTION
## Summary
- block decimal (`2130706433`) and hex (`0x7f000001`) IPv4 literal hosts from backend fulfillment targets
- apply the same hardening in both product input validation and runtime fulfillment target checks
- add regression tests proving loopback-bypass payloads are rejected

## Why
Numeric IPv4 literal formats can resolve to loopback/private addresses while bypassing the previous host-shape detector, enabling SSRF to internal services.

## Testing
- `mvn -q -Dtest=ProductServiceTest,ProductFulfillmentApiServiceTest test`
