### PR TITLE
fix: reject malformed conversation ids with empty segments

### DIFF
--- a/src/main/java/ltdjms/discord/aiagent/domain/ConversationIdBuilder.java
+++ b/src/main/java/ltdjms/discord/aiagent/domain/ConversationIdBuilder.java
@@ -70,7 +70,12 @@ public final class ConversationIdBuilder {
       throw new IllegalArgumentException("會話 ID 不能為空");
     }
 
-    String[] parts = conversationId.split(":");
+    String[] parts = conversationId.split(":", -1);
+    for (String part : parts) {
+      if (part.isBlank()) {
+        throw new IllegalArgumentException("無效的會話 ID 格式: " + conversationId + "（含空白段）");
+      }
+    }
     return switch (parts.length) {
       case 3 -> ConversationIdStrategy.THREAD_LEVEL;
       case 4 -> ConversationIdStrategy.MESSAGE_LEVEL;

--- a/src/test/java/ltdjms/discord/aiagent/domain/AIAgentDomainTest.java
+++ b/src/test/java/ltdjms/discord/aiagent/domain/AIAgentDomainTest.java
@@ -795,6 +795,30 @@ class AIAgentDomainTest {
     }
 
     @Test
+    @DisplayName("should reject conversation ID with trailing delimiter")
+    void shouldRejectConversationIdWithTrailingDelimiter() {
+      // Given
+      String id = "123:999:789:";
+
+      // When/Then
+      assertThatThrownBy(() -> ConversationIdBuilder.parseStrategy(id))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("無效的會話 ID 格式");
+    }
+
+    @Test
+    @DisplayName("should reject conversation ID with empty segment")
+    void shouldRejectConversationIdWithEmptySegment() {
+      // Given
+      String id = "123::789";
+
+      // When/Then
+      assertThatThrownBy(() -> ConversationIdBuilder.parseStrategy(id))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("無效的會話 ID 格式");
+    }
+
+    @Test
     @DisplayName("should throw exception for null conversation ID")
     void shouldThrowExceptionForNullConversationId() {
       // When/Then


### PR DESCRIPTION
## Summary
- preserve empty segments when parsing conversation IDs (`split(":", -1)`)
- reject IDs that contain empty segments (including trailing delimiters)
- add regression tests for trailing delimiter and middle empty segment

## Edge cases covered
- `123:999:789:` no longer misclassified as a valid thread-level ID
- `123::789` now rejected as invalid input

## Testing
- `mvn -q -Dtest=AIAgentDomainTest,SimplifiedChatMemoryProviderTest test`
