### PR TITLE
fix(security): enforce HTTPS for backend fulfillment URLs

### DIFF
--- a/src/main/java/ltdjms/discord/product/services/ProductService.java
+++ b/src/main/java/ltdjms/discord/product/services/ProductService.java
@@ -381,9 +381,8 @@ public class ProductService {
     try {
       URI uri = URI.create(normalized);
       String scheme = uri.getScheme();
-      if (scheme == null
-          || (!"http".equalsIgnoreCase(scheme) && !"https".equalsIgnoreCase(scheme))) {
-        return Result.err(DomainError.invalidInput("後端 API URL 必須使用 http:// 或 https://"));
+      if (scheme == null || !"https".equalsIgnoreCase(scheme)) {
+        return Result.err(DomainError.invalidInput("後端 API URL 必須使用 https://"));
       }
       if (uri.getHost() == null || uri.getHost().isBlank()) {
         return Result.err(DomainError.invalidInput("後端 API URL 格式無效"));

--- a/src/main/java/ltdjms/discord/shop/services/ProductFulfillmentApiService.java
+++ b/src/main/java/ltdjms/discord/shop/services/ProductFulfillmentApiService.java
@@ -225,6 +225,9 @@ public class ProductFulfillmentApiService {
     if (host == null || host.isBlank()) {
       return Result.err(DomainError.invalidInput("後端履約 API URL 格式無效"));
     }
+    if (!"https".equalsIgnoreCase(uri.getScheme())) {
+      return Result.err(DomainError.invalidInput("後端履約 API URL 必須使用 https://"));
+    }
 
     String normalizedHost = host.trim().toLowerCase();
     if (normalizedHost.equals("localhost") || normalizedHost.endsWith(".localhost")) {

--- a/src/test/java/ltdjms/discord/product/services/ProductServiceTest.java
+++ b/src/test/java/ltdjms/discord/product/services/ProductServiceTest.java
@@ -291,12 +291,35 @@ class ProductServiceTest {
               null,
               300L,
               null,
-              "http://127.0.0.1/internal",
+              "https://127.0.0.1/internal",
               false,
               null);
 
       assertThat(result.isErr()).isTrue();
       assertThat(result.getError().message()).contains("localhost 或內網位址");
+    }
+
+    @Test
+    @DisplayName("should reject non-https backend API URL")
+    void shouldRejectNonHttpsBackendApiUrl() {
+      when(productRepository.existsByGuildIdAndName(TEST_GUILD_ID, "Insecure Backend"))
+          .thenReturn(false);
+
+      Result<Product, DomainError> result =
+          productService.createProduct(
+              TEST_GUILD_ID,
+              "Insecure Backend",
+              "desc",
+              null,
+              null,
+              300L,
+              null,
+              "http://backend.example.com/fulfill",
+              false,
+              null);
+
+      assertThat(result.isErr()).isTrue();
+      assertThat(result.getError().message()).contains("必須使用 https://");
     }
 
     @Test

--- a/src/test/java/ltdjms/discord/shop/services/ProductFulfillmentApiServiceTest.java
+++ b/src/test/java/ltdjms/discord/shop/services/ProductFulfillmentApiServiceTest.java
@@ -228,7 +228,7 @@ class ProductFulfillmentApiServiceTest {
             100L,
             200L,
             null,
-            "http://localhost:8080/internal",
+            "https://localhost:8080/internal",
             false,
             null,
             Instant.now(),
@@ -293,6 +293,40 @@ class ProductFulfillmentApiServiceTest {
 
     assertThat(result.isErr()).isTrue();
     assertThat(result.getError().message()).contains("localhost 或內網位址");
+    verify(httpClient, never()).send(any(), anyStringBodyHandler());
+  }
+
+  @Test
+  @DisplayName("應拒絕非 https 的履約目標 URL")
+  void shouldRejectNonHttpsTarget() throws Exception {
+    Product product =
+        new Product(
+            1L,
+            GUILD_ID,
+            "Insecure Backend",
+            null,
+            Product.RewardType.CURRENCY,
+            100L,
+            200L,
+            null,
+            "http://backend.example.com/fulfill",
+            false,
+            null,
+            Instant.now(),
+            Instant.now());
+
+    Result<ltdjms.discord.shared.Unit, DomainError> result =
+        service.notifyFulfillment(
+            new ProductFulfillmentApiService.FulfillmentRequest(
+                GUILD_ID,
+                USER_ID,
+                product,
+                ProductFulfillmentApiService.PurchaseSource.CURRENCY_PURCHASE,
+                null,
+                null));
+
+    assertThat(result.isErr()).isTrue();
+    assertThat(result.getError().message()).contains("必須使用 https://");
     verify(httpClient, never()).send(any(), anyStringBodyHandler());
   }
 }


### PR DESCRIPTION
## Summary
- enforce  only for product backend API URL validation in 
- add runtime defense in  to reject non-HTTPS targets before outbound call
- add regression tests for non-HTTPS URL rejection and keep localhost/private-address checks covered

## Security impact
- prevents plaintext fulfillment callback traffic to third-party endpoints
- reduces risk of MITM/data tampering for fulfillment payloads (guild/user/order context)

## Testing
- 21:04:50,202 |-INFO in ch.qos.logback.classic.LoggerContext[default] - This is logback-classic version 1.5.12
21:04:50,203 |-INFO in ch.qos.logback.classic.util.ContextInitializer@852ef8d - No custom configurators were discovered as a service.
21:04:50,203 |-INFO in ch.qos.logback.classic.util.ContextInitializer@852ef8d - Trying to configure with ch.qos.logback.classic.joran.SerializedModelConfigurator
21:04:50,203 |-INFO in ch.qos.logback.classic.util.ContextInitializer@852ef8d - Constructed configurator of type class ch.qos.logback.classic.joran.SerializedModelConfigurator
21:04:50,203 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback-test.scmo]
21:04:50,203 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback.scmo]
21:04:50,204 |-INFO in ch.qos.logback.classic.util.ContextInitializer@852ef8d - ch.qos.logback.classic.joran.SerializedModelConfigurator.configure() call lasted 1 milliseconds. ExecutionStatus=INVOKE_NEXT_IF_ANY
21:04:50,204 |-INFO in ch.qos.logback.classic.util.ContextInitializer@852ef8d - Trying to configure with ch.qos.logback.classic.util.DefaultJoranConfigurator
21:04:50,205 |-INFO in ch.qos.logback.classic.util.ContextInitializer@852ef8d - Constructed configurator of type class ch.qos.logback.classic.util.DefaultJoranConfigurator
21:04:50,205 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback-test.xml]
21:04:50,205 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Found resource [logback.xml] at [file:/Users/tszkinlai/.codex/worktrees/4d77/LTDJMS/target/classes/logback.xml]
21:04:50,264 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@44dd0d38 - value "logs" substituted for "${LOG_DIR:-logs}"
21:04:50,264 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@44dd0d38 - value "WARN" substituted for "${LOG_LEVEL:-WARN}"
21:04:50,264 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@44dd0d38 - value "INFO" substituted for "${APP_LOG_LEVEL:-INFO}"
21:04:50,264 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@44dd0d38 - value "20MB" substituted for "${LOG_MAX_FILE_SIZE:-20MB}"
21:04:50,264 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@44dd0d38 - value "30" substituted for "${LOG_MAX_HISTORY_DAYS:-30}"
21:04:50,264 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@44dd0d38 - value "3GB" substituted for "${LOG_TOTAL_SIZE_CAP:-3GB}"
21:04:50,266 |-INFO in ch.qos.logback.classic.model.processor.ConfigurationModelHandlerFull - Registering a new ReconfigureOnChangeTask ReconfigureOnChangeTask(born:1773061490265)
21:04:50,266 |-INFO in ch.qos.logback.classic.model.processor.ConfigurationModelHandlerFull - Will scan for changes in [ConfigurationWatchList(mainURL=file:/Users/tszkinlai/.codex/worktrees/4d77/LTDJMS/target/classes/logback.xml, fileWatchList={/Users/tszkinlai/.codex/worktrees/4d77/LTDJMS/target/classes/logback.xml}, urlWatchList=[})] 
21:04:50,266 |-INFO in ch.qos.logback.classic.model.processor.ConfigurationModelHandlerFull - Setting ReconfigureOnChangeTask scanning period to 30 seconds
21:04:50,268 |-INFO in ch.qos.logback.core.model.processor.AppenderModelHandler - Processing appender named [CONSOLE]
21:04:50,268 |-INFO in ch.qos.logback.core.model.processor.AppenderModelHandler - About to instantiate appender of type [ch.qos.logback.core.ConsoleAppender]
21:04:50,272 |-INFO in ch.qos.logback.core.model.processor.ImplicitModelHandler - Assuming default type [ch.qos.logback.classic.encoder.PatternLayoutEncoder] for [encoder] property
21:04:50,273 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@44dd0d38 - value "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n" substituted for "${LOG_PATTERN}"
21:04:50,292 |-WARN in ch.qos.logback.core.model.processor.AppenderModelHandler - Appender named [JSON_CONSOLE] not referenced. Skipping further processing.
21:04:50,292 |-INFO in ch.qos.logback.core.model.processor.AppenderModelHandler - Processing appender named [APP_FILE]
21:04:50,292 |-INFO in ch.qos.logback.core.model.processor.AppenderModelHandler - About to instantiate appender of type [ch.qos.logback.core.rolling.RollingFileAppender]
21:04:50,295 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@44dd0d38 - value "logs/app.log" substituted for "${LOG_DIR}/app.log"
21:04:50,297 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@44dd0d38 - value "logs/archive/app.%d{yyyy-MM-dd}.%i.log.gz" substituted for "${LOG_DIR}/archive/app.%d{yyyy-MM-dd}.%i.log.gz"
21:04:50,297 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@44dd0d38 - value "20MB" substituted for "${LOG_MAX_FILE_SIZE}"
21:04:50,297 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@44dd0d38 - value "30" substituted for "${LOG_MAX_HISTORY_DAYS}"
21:04:50,298 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@44dd0d38 - value "3GB" substituted for "${LOG_TOTAL_SIZE_CAP}"
21:04:50,298 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@2123686705 - setting totalSizeCap to 3 GB
21:04:50,302 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@2123686705 - Archive files will be limited to [20 MB] each.
21:04:50,303 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@2123686705 - Will use gz compression
21:04:50,304 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@2123686705 - Will use the pattern logs/archive/app.%d{yyyy-MM-dd}.%i.log for the active file
21:04:50,315 |-INFO in ch.qos.logback.core.rolling.SizeAndTimeBasedFileNamingAndTriggeringPolicy@539fc5d1 - The date pattern is 'yyyy-MM-dd' from file name pattern 'logs/archive/app.%d{yyyy-MM-dd}.%i.log.gz'.
21:04:50,315 |-INFO in ch.qos.logback.core.rolling.SizeAndTimeBasedFileNamingAndTriggeringPolicy@539fc5d1 - Roll-over at midnight.
21:04:50,320 |-INFO in ch.qos.logback.core.rolling.SizeAndTimeBasedFileNamingAndTriggeringPolicy@539fc5d1 - Setting initial period to 2026-03-09T13:04:10.833Z
21:04:50,321 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@2123686705 - Cleaning on start up
21:04:50,321 |-INFO in c.q.l.core.rolling.helper.TimeBasedArchiveRemover - first clean up after appender initialization
21:04:50,322 |-INFO in ch.qos.logback.core.model.processor.ImplicitModelHandler - Assuming default type [ch.qos.logback.classic.encoder.PatternLayoutEncoder] for [encoder] property
21:04:50,322 |-INFO in c.q.l.core.rolling.helper.TimeBasedArchiveRemover - Multiple periods, i.e. 32 periods, seem to have elapsed. This is expected at application start.
21:04:50,322 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@44dd0d38 - value "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n" substituted for "${LOG_PATTERN}"
21:04:50,323 |-INFO in ch.qos.logback.core.rolling.RollingFileAppender[APP_FILE] - Active log file name: logs/app.log
21:04:50,323 |-INFO in ch.qos.logback.core.rolling.RollingFileAppender[APP_FILE] - Setting currentFileLength to 58514 for logs/app.log
21:04:50,323 |-INFO in ch.qos.logback.core.rolling.RollingFileAppender[APP_FILE] - File property is set to [logs/app.log]
21:04:50,324 |-INFO in ch.qos.logback.core.model.processor.AppenderModelHandler - Processing appender named [WARN_FILE]
21:04:50,324 |-INFO in ch.qos.logback.core.model.processor.AppenderModelHandler - About to instantiate appender of type [ch.qos.logback.core.rolling.RollingFileAppender]
21:04:50,324 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@44dd0d38 - value "logs/warn.log" substituted for "${LOG_DIR}/warn.log"
21:04:50,324 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@44dd0d38 - value "logs/archive/warn.%d{yyyy-MM-dd}.%i.log.gz" substituted for "${LOG_DIR}/archive/warn.%d{yyyy-MM-dd}.%i.log.gz"
21:04:50,324 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@44dd0d38 - value "20MB" substituted for "${LOG_MAX_FILE_SIZE}"
21:04:50,325 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@44dd0d38 - value "30" substituted for "${LOG_MAX_HISTORY_DAYS}"
21:04:50,325 |-INFO in c.q.l.core.rolling.helper.TimeBasedArchiveRemover - No removal attempts were made.
21:04:50,325 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@44dd0d38 - value "3GB" substituted for "${LOG_TOTAL_SIZE_CAP}"
21:04:50,325 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@1286497960 - setting totalSizeCap to 3 GB
21:04:50,325 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@1286497960 - Archive files will be limited to [20 MB] each.
21:04:50,325 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@1286497960 - Will use gz compression
21:04:50,325 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@1286497960 - Will use the pattern logs/archive/warn.%d{yyyy-MM-dd}.%i.log for the active file
21:04:50,325 |-INFO in ch.qos.logback.core.rolling.SizeAndTimeBasedFileNamingAndTriggeringPolicy@60b616c8 - The date pattern is 'yyyy-MM-dd' from file name pattern 'logs/archive/warn.%d{yyyy-MM-dd}.%i.log.gz'.
21:04:50,325 |-INFO in ch.qos.logback.core.rolling.SizeAndTimeBasedFileNamingAndTriggeringPolicy@60b616c8 - Roll-over at midnight.
21:04:50,325 |-INFO in ch.qos.logback.core.rolling.SizeAndTimeBasedFileNamingAndTriggeringPolicy@60b616c8 - Setting initial period to 2026-03-09T13:04:10.823Z
21:04:50,325 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@1286497960 - Cleaning on start up
21:04:50,325 |-INFO in c.q.l.core.rolling.helper.TimeBasedArchiveRemover - first clean up after appender initialization
21:04:50,325 |-INFO in ch.qos.logback.core.model.processor.ImplicitModelHandler - Assuming default type [ch.qos.logback.classic.encoder.PatternLayoutEncoder] for [encoder] property
21:04:50,325 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@44dd0d38 - value "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n" substituted for "${LOG_PATTERN}"
21:04:50,325 |-INFO in c.q.l.core.rolling.helper.TimeBasedArchiveRemover - Multiple periods, i.e. 32 periods, seem to have elapsed. This is expected at application start.
21:04:50,326 |-INFO in ch.qos.logback.core.rolling.RollingFileAppender[WARN_FILE] - Active log file name: logs/warn.log
21:04:50,326 |-INFO in ch.qos.logback.core.rolling.RollingFileAppender[WARN_FILE] - Setting currentFileLength to 54012 for logs/warn.log
21:04:50,326 |-INFO in ch.qos.logback.core.rolling.RollingFileAppender[WARN_FILE] - File property is set to [logs/warn.log]
21:04:50,326 |-INFO in ch.qos.logback.core.model.processor.AppenderModelHandler - Processing appender named [ERROR_FILE]
21:04:50,326 |-INFO in ch.qos.logback.core.model.processor.AppenderModelHandler - About to instantiate appender of type [ch.qos.logback.core.rolling.RollingFileAppender]
21:04:50,326 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@44dd0d38 - value "logs/error.log" substituted for "${LOG_DIR}/error.log"
21:04:50,327 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@44dd0d38 - value "logs/archive/error.%d{yyyy-MM-dd}.%i.log.gz" substituted for "${LOG_DIR}/archive/error.%d{yyyy-MM-dd}.%i.log.gz"
21:04:50,327 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@44dd0d38 - value "20MB" substituted for "${LOG_MAX_FILE_SIZE}"
21:04:50,327 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@44dd0d38 - value "30" substituted for "${LOG_MAX_HISTORY_DAYS}"
21:04:50,327 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@44dd0d38 - value "3GB" substituted for "${LOG_TOTAL_SIZE_CAP}"
21:04:50,327 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@962784388 - setting totalSizeCap to 3 GB
21:04:50,327 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@962784388 - Archive files will be limited to [20 MB] each.
21:04:50,327 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@962784388 - Will use gz compression
21:04:50,327 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@962784388 - Will use the pattern logs/archive/error.%d{yyyy-MM-dd}.%i.log for the active file
21:04:50,327 |-INFO in ch.qos.logback.core.rolling.SizeAndTimeBasedFileNamingAndTriggeringPolicy@147e0734 - The date pattern is 'yyyy-MM-dd' from file name pattern 'logs/archive/error.%d{yyyy-MM-dd}.%i.log.gz'.
21:04:50,327 |-INFO in ch.qos.logback.core.rolling.SizeAndTimeBasedFileNamingAndTriggeringPolicy@147e0734 - Roll-over at midnight.
21:04:50,327 |-INFO in ch.qos.logback.core.rolling.SizeAndTimeBasedFileNamingAndTriggeringPolicy@147e0734 - Setting initial period to 2026-03-09T13:04:10.823Z
21:04:50,327 |-INFO in c.q.l.core.rolling.SizeAndTimeBasedRollingPolicy@962784388 - Cleaning on start up
21:04:50,328 |-INFO in ch.qos.logback.core.model.processor.ImplicitModelHandler - Assuming default type [ch.qos.logback.classic.encoder.PatternLayoutEncoder] for [encoder] property
21:04:50,328 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@44dd0d38 - value "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n" substituted for "${LOG_PATTERN}"
21:04:50,328 |-INFO in c.q.l.core.rolling.helper.TimeBasedArchiveRemover - first clean up after appender initialization
21:04:50,328 |-INFO in c.q.l.core.rolling.helper.TimeBasedArchiveRemover - Multiple periods, i.e. 32 periods, seem to have elapsed. This is expected at application start.
21:04:50,328 |-INFO in ch.qos.logback.core.rolling.RollingFileAppender[ERROR_FILE] - Active log file name: logs/error.log
21:04:50,328 |-INFO in ch.qos.logback.core.rolling.RollingFileAppender[ERROR_FILE] - Setting currentFileLength to 53288 for logs/error.log
21:04:50,328 |-INFO in ch.qos.logback.core.rolling.RollingFileAppender[ERROR_FILE] - File property is set to [logs/error.log]
21:04:50,328 |-INFO in c.q.l.core.rolling.helper.TimeBasedArchiveRemover - No removal attempts were made.
21:04:50,328 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@44dd0d38 - value "INFO" substituted for "${APP_LOG_LEVEL}"
21:04:50,328 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [ltdjms.discord] to INFO
21:04:50,328 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [ltdjms.discord.currency.bot] to INFO
21:04:50,328 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [ltdjms.discord.currency.commands] to INFO
21:04:50,328 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [ltdjms.discord.currency.services] to INFO
21:04:50,328 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [ltdjms.discord.currency.persistence] to INFO
21:04:50,328 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [ltdjms.discord.discord] to INFO
21:04:50,328 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [ltdjms.discord.discord.adapter] to DEBUG
21:04:50,328 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [ltdjms.discord.aichat] to INFO
21:04:50,328 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [ltdjms.discord.aichat.commands] to INFO
21:04:50,328 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [ltdjms.discord.aichat.services] to INFO
21:04:50,328 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [net.dv8tion.jda] to INFO
21:04:50,328 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [net.dv8tion.jda.internal.requests] to WARN
21:04:50,328 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [net.dv8tion.jda.api.requests] to WARN
21:04:50,328 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [com.zaxxer.hikari] to INFO
21:04:50,328 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [com.zaxxer.hikari.pool] to INFO
21:04:50,328 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [org.postgresql] to WARN
21:04:50,328 |-INFO in ch.qos.logback.core.model.processor.ModelInterpretationContext@44dd0d38 - value "WARN" substituted for "${LOG_LEVEL}"
21:04:50,328 |-INFO in ch.qos.logback.classic.model.processor.RootLoggerModelHandler - Setting level of ROOT logger to WARN
21:04:50,328 |-INFO in ch.qos.logback.core.model.processor.AppenderRefModelHandler - Attaching appender named [CONSOLE] to Logger[ROOT]
21:04:50,329 |-INFO in ch.qos.logback.core.model.processor.AppenderRefModelHandler - Attaching appender named [APP_FILE] to Logger[ROOT]
21:04:50,329 |-INFO in ch.qos.logback.core.model.processor.AppenderRefModelHandler - Attaching appender named [WARN_FILE] to Logger[ROOT]
21:04:50,329 |-INFO in ch.qos.logback.core.model.processor.AppenderRefModelHandler - Attaching appender named [ERROR_FILE] to Logger[ROOT]
21:04:50,329 |-INFO in ch.qos.logback.core.model.processor.DefaultProcessor@2bdab835 - End of configuration.
21:04:50,329 |-INFO in ch.qos.logback.classic.joran.JoranConfigurator@7b8aebd0 - Registering current configuration as safe fallback point
21:04:50,329 |-INFO in ch.qos.logback.classic.util.ContextInitializer@852ef8d - ch.qos.logback.classic.util.DefaultJoranConfigurator.configure() call lasted 124 milliseconds. ExecutionStatus=DO_NOT_INVOKE_NEXT_IF_ANY
21:04:50,329 |-INFO in c.q.l.core.rolling.helper.TimeBasedArchiveRemover - No removal attempts were made.

2026-03-09 21:04:50.856 [main] WARN  l.d.s.s.ProductFulfillmentApiService - Blocked backend fulfillment target resolving to non-public address: host=attacker.example, resolvedAddress=127.0.0.1
2026-03-09 21:04:50.905 [main] INFO  l.d.s.s.ProductFulfillmentApiService - Backend fulfillment notified: guildId=123, userId=456, productId=1, source=CURRENCY_PURCHASE
2026-03-09 21:04:50.914 [main] WARN  l.d.s.s.ProductFulfillmentApiService - Backend fulfillment API failed: status=500, guildId=123, userId=456, productId=1, body=error
2026-03-09 21:04:51.038 [main] ERROR l.d.product.services.ProductService - Failed to delete product id=1
java.lang.RuntimeException: Database error
	at ltdjms.discord.product.services.ProductService.deleteProduct(ProductService.java:475)
	at ltdjms.discord.product.services.ProductServiceTest$DeleteProductTests.shouldHandlePersistenceFailureOnDelete(ProductServiceTest.java:626)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:767)
	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:156)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:147)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:86)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(InterceptingExecutableInvoker.java:103)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.lambda$invoke$0(InterceptingExecutableInvoker.java:93)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:92)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:86)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$8(TestMethodTestDescriptor.java:217)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:213)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:138)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:68)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:156)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:146)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:144)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:143)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:100)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1604)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:160)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:146)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:144)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:143)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:100)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1604)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:160)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:146)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:144)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:143)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:100)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1604)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:160)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:146)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:144)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:143)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:100)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:198)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:169)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:93)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:58)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:141)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:57)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:103)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:85)
	at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
	at org.apache.maven.surefire.junitplatform.LazyLauncher.execute(LazyLauncher.java:56)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:184)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:148)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:122)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
	at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)
2026-03-09 21:04:51.042 [main] INFO  l.d.product.services.ProductService - Deleted product: id=1
2026-03-09 21:04:51.046 [main] INFO  l.d.product.services.ProductService - Invalidated 5 redemption codes before deleting product: id=1
2026-03-09 21:04:51.046 [main] INFO  l.d.product.services.ProductService - Deleted product: id=1
2026-03-09 21:04:51.051 [main] INFO  l.d.product.services.ProductService - Deleted product: id=1
2026-03-09 21:04:51.054 [main] INFO  l.d.product.services.ProductService - Updated product: id=1, name=New
2026-03-09 21:04:51.057 [main] ERROR l.d.product.services.ProductService - Failed to update product id=1
java.lang.RuntimeException: Database error
	at ltdjms.discord.product.services.ProductService.updateProductInternal(ProductService.java:286)
	at ltdjms.discord.product.services.ProductService.updateProduct(ProductService.java:162)
	at ltdjms.discord.product.services.ProductServiceTest$UpdateProductTests.shouldHandlePersistenceFailureOnUpdate(ProductServiceTest.java:509)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:767)
	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:156)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:147)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:86)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(InterceptingExecutableInvoker.java:103)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.lambda$invoke$0(InterceptingExecutableInvoker.java:93)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:92)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:86)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$8(TestMethodTestDescriptor.java:217)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:213)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:138)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:68)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:156)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:146)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:144)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:143)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:100)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1604)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:160)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:146)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:144)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:143)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:100)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1604)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:160)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:146)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:144)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:143)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:100)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1604)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:160)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:146)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:144)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:143)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:100)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:198)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:169)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:93)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:58)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:141)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:57)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:103)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:85)
	at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
	at org.apache.maven.surefire.junitplatform.LazyLauncher.execute(LazyLauncher.java:56)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:184)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:148)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:122)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
	at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)
2026-03-09 21:04:51.064 [main] INFO  l.d.product.services.ProductService - Updated product: id=1, name=新名稱
2026-03-09 21:04:51.073 [main] ERROR l.d.product.services.ProductService - Failed to create product for guildId=123456789012345678, name=Test
java.lang.RuntimeException: Database error
	at ltdjms.discord.product.services.ProductService.createProduct(ProductService.java:121)
	at ltdjms.discord.product.services.ProductService.createProduct(ProductService.java:59)
	at ltdjms.discord.product.services.ProductService.createProduct(ProductService.java:48)
	at ltdjms.discord.product.services.ProductServiceTest$CreateProductTests.shouldHandlePersistenceFailureOnCreate(ProductServiceTest.java:335)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:767)
	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:156)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:147)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:86)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(InterceptingExecutableInvoker.java:103)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.lambda$invoke$0(InterceptingExecutableInvoker.java:93)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:92)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:86)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$8(TestMethodTestDescriptor.java:217)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:213)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:138)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:68)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:156)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:146)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:144)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:143)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:100)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1604)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:160)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:146)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:144)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:143)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:100)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1604)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:160)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:146)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:144)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:143)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:100)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1604)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:160)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:146)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:144)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:143)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:100)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:198)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:169)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:93)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:58)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:141)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:57)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:103)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:85)
	at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
	at org.apache.maven.surefire.junitplatform.LazyLauncher.execute(LazyLauncher.java:56)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:184)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:148)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:122)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
	at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)
2026-03-09 21:04:51.075 [main] INFO  l.d.product.services.ProductService - Created product: guildId=123456789012345678, name=VIP 服務, rewardType=null, rewardAmount=null, currencyPrice=null, fiatPriceTwd=null, hasBackendApi=false, autoCreateEscortOrder=false, escortOptionCode=null
2026-03-09 21:04:51.077 [main] INFO  l.d.product.services.ProductService - Created product: guildId=123456789012345678, name=新手禮包, rewardType=CURRENCY, rewardAmount=1000, currencyPrice=null, fiatPriceTwd=null, hasBackendApi=false, autoCreateEscortOrder=false, escortOptionCode=null
2026-03-09 21:04:51.080 [main] INFO  l.d.product.services.ProductService - Created product: guildId=123456789012345678, name=Premium Product, rewardType=null, rewardAmount=null, currencyPrice=500, fiatPriceTwd=null, hasBackendApi=false, autoCreateEscortOrder=false, escortOptionCode=null
2026-03-09 21:04:51.081 [main] INFO  l.d.product.services.ProductService - Created product: guildId=123456789012345678, name=Backend Product, rewardType=null, rewardAmount=null, currencyPrice=300, fiatPriceTwd=null, hasBackendApi=true, autoCreateEscortOrder=false, escortOptionCode=null
2026-03-09 21:04:51.082 [main] INFO  l.d.product.services.ProductService - Created product: guildId=123456789012345678, name=Test Product, rewardType=null, rewardAmount=null, currencyPrice=null, fiatPriceTwd=null, hasBackendApi=false, autoCreateEscortOrder=false, escortOptionCode=null
