### PR TITLE
fix: reject malformed conversation ids with empty segments

### DIFF
--- a/src/main/java/ltdjms/discord/aiagent/domain/ConversationIdBuilder.java
+++ b/src/main/java/ltdjms/discord/aiagent/domain/ConversationIdBuilder.java
@@ -70,7 +70,12 @@ public final class ConversationIdBuilder {
       throw new IllegalArgumentException("會話 ID 不能為空");
     }
 
-    String[] parts = conversationId.split(":");
+    String[] parts = conversationId.split(":", -1);
+    for (String part : parts) {
+      if (part == null || part.isBlank()) {
+        throw new IllegalArgumentException("無效的會話 ID 格式: " + conversationId + "（包含空白段）");
+      }
+    }
     return switch (parts.length) {
       case 3 -> ConversationIdStrategy.THREAD_LEVEL;
       case 4 -> ConversationIdStrategy.MESSAGE_LEVEL;

--- a/src/test/java/ltdjms/discord/aiagent/domain/AIAgentDomainTest.java
+++ b/src/test/java/ltdjms/discord/aiagent/domain/AIAgentDomainTest.java
@@ -795,6 +795,30 @@ class AIAgentDomainTest {
     }
 
     @Test
+    @DisplayName("should reject thread-level conversation ID with trailing delimiter")
+    void shouldRejectThreadLevelConversationIdWithTrailingDelimiter() {
+      // Given
+      String id = "123:999:789:";
+
+      // When/Then
+      assertThatThrownBy(() -> ConversationIdBuilder.parseStrategy(id))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("無效的會話 ID 格式");
+    }
+
+    @Test
+    @DisplayName("should reject conversation ID containing empty segment")
+    void shouldRejectConversationIdContainingEmptySegment() {
+      // Given
+      String id = "123::789";
+
+      // When/Then
+      assertThatThrownBy(() -> ConversationIdBuilder.parseStrategy(id))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("無效的會話 ID 格式");
+    }
+
+    @Test
     @DisplayName("should throw exception for null conversation ID")
     void shouldThrowExceptionForNullConversationId() {
       // When/Then


### PR DESCRIPTION
## Summary
- harden `ConversationIdBuilder.parseStrategy` to preserve trailing delimiters via `split(":", -1)`
- reject conversation IDs containing any blank segment before strategy classification
- add regression tests for trailing delimiter and middle empty segment inputs

## Edge Cases Covered
- `123:999:789:` should be invalid instead of thread-level
- `123::789` should be invalid instead of thread-level

## Tests
- `mvn -q -Dtest=AIAgentDomainTest test` (fails before fix, passes after)
- `mvn -q -Dtest=AIAgentDomainTest,SimplifiedChatMemoryProviderTest test`

## Risk
- Low: only conversation ID parsing validation tightened; valid 3/4-segment IDs are unchanged.
