### PR TITLE
fix: prevent duplicate fiat fulfillment on replayed paid callbacks

### DIFF
--- a/src/main/java/ltdjms/discord/shop/services/FiatPaymentCallbackService.java
+++ b/src/main/java/ltdjms/discord/shop/services/FiatPaymentCallbackService.java
@@ -153,6 +153,12 @@ public class FiatPaymentCallbackService {
   }
 
   private void handlePostPayment(FiatOrder order) {
+    if (order.isFulfilled()) {
+      LOG.info(
+          "Skip fulfillment for already-fulfilled paid order: orderNumber={}", order.orderNumber());
+      return;
+    }
+
     Product product = productService.getProduct(order.productId()).orElse(null);
     if (product == null) {
       LOG.warn(

--- a/src/test/java/ltdjms/discord/shop/services/FiatPaymentCallbackServiceTest.java
+++ b/src/test/java/ltdjms/discord/shop/services/FiatPaymentCallbackServiceTest.java
@@ -156,6 +156,52 @@ class FiatPaymentCallbackServiceTest {
   }
 
   @Test
+  @DisplayName("已履約訂單收到重複付款回推時不應再次呼叫履約 API")
+  void shouldNotCallFulfillmentApiWhenOrderAlreadyFulfilled() {
+    FiatOrder fulfilledOrder =
+        new FiatOrder(
+            1L,
+            GUILD_ID,
+            BUYER_ID,
+            PRODUCT_ID,
+            "護航商品",
+            ORDER_NUMBER,
+            "ABC123456789",
+            1200L,
+            FiatOrder.Status.PAID,
+            "1",
+            "付款成功",
+            Instant.now(fixedClock),
+            Instant.now(fixedClock),
+            Instant.now(fixedClock),
+            null,
+            Instant.now(fixedClock),
+            Instant.now(fixedClock));
+
+    when(fiatOrderRepository.findByOrderNumber(ORDER_NUMBER))
+        .thenReturn(Optional.of(fulfilledOrder));
+    when(fiatOrderRepository.markPaidIfPending(
+            eq(ORDER_NUMBER), eq("1"), eq("付款成功"), any(), any(Instant.class)))
+        .thenReturn(Optional.empty());
+    when(fiatOrderRepository.updateCallbackStatus(eq(ORDER_NUMBER), eq("1"), eq("付款成功"), any()))
+        .thenReturn(Optional.of(fulfilledOrder));
+
+    FiatPaymentCallbackService.CallbackResult result =
+        service.handleCallback(
+            encryptedPayload(
+                """
+                {"MerchantID":"2000132","MerchantTradeNo":"FD260304000001","TradeAmt":"1200","TradeStatus":"1","RtnCode":1,"RtnMsg":"付款成功"}
+                """),
+            "application/json");
+
+    assertThat(result.httpStatus()).isEqualTo(200);
+    verify(productFulfillmentApiService, never()).notifyFulfillment(any());
+    verify(fiatOrderRepository, never()).markFulfilledIfNeeded(any(), any(Instant.class));
+    verify(adminNotificationService, never())
+        .notifyAdminsOrderCreated(anyLong(), anyLong(), any(), any(), any());
+  }
+
+  @Test
   @DisplayName("未付款回推應僅更新狀態不觸發履約")
   void shouldOnlyUpdateStatusWhenUnpaid() {
     when(fiatOrderRepository.findByOrderNumber(ORDER_NUMBER))


### PR DESCRIPTION
## Related issues or motivation
- Security hardening: duplicate/replayed paid callbacks could trigger fulfillment API repeatedly after an order was already fulfilled.

## Engineering decisions
- Added an early return in `FiatPaymentCallbackService.handlePostPayment` when `FiatOrder.isFulfilled()` is true.
- This keeps retries for paid-but-not-fulfilled orders intact, while blocking duplicate delivery for already fulfilled orders.
- Added regression test covering duplicate paid callback on already fulfilled order.

## Test results
- `mvn -Dtest=FiatPaymentCallbackServiceTest test`
