### PR TITLE
Fix inconsistent product reward fulfillment

### DIFF
--- a/src/main/java/ltdjms/discord/currency/domain/CurrencyTransaction.java
+++ b/src/main/java/ltdjms/discord/currency/domain/CurrencyTransaction.java
@@ -35,8 +35,12 @@ public record CurrencyTransaction(
     DICE_GAME_2_WIN("骰子遊戲 2 獎勵"),
     /** Currency granted from redeeming a redemption code */
     REDEMPTION_CODE("兌換碼獎勵"),
+    /** Currency granted as a product reward */
+    PRODUCT_REWARD("商品獎勵"),
     /** Currency spent to purchase a product from shop */
-    PRODUCT_PURCHASE("商品購買");
+    PRODUCT_PURCHASE("商品購買"),
+    /** Currency refunded after a failed product purchase reward workflow */
+    PRODUCT_PURCHASE_REFUND("商品購買退款");
 
     private final String displayName;
 

--- a/src/main/java/ltdjms/discord/gametoken/domain/GameTokenTransaction.java
+++ b/src/main/java/ltdjms/discord/gametoken/domain/GameTokenTransaction.java
@@ -40,7 +40,9 @@ public record GameTokenTransaction(
     /** Initial account creation */
     INITIAL("初始化"),
     /** Tokens granted from redeeming a redemption code */
-    REDEMPTION_CODE("兌換碼獎勵");
+    REDEMPTION_CODE("兌換碼獎勵"),
+    /** Tokens granted as a product reward */
+    PRODUCT_REWARD("商品獎勵");
 
     private final String displayName;
 

--- a/src/main/java/ltdjms/discord/product/services/ProductRewardService.java
+++ b/src/main/java/ltdjms/discord/product/services/ProductRewardService.java
@@ -1,0 +1,111 @@
+package ltdjms.discord.product.services;
+
+import ltdjms.discord.currency.domain.CurrencyTransaction;
+import ltdjms.discord.currency.services.BalanceAdjustmentService;
+import ltdjms.discord.currency.services.CurrencyTransactionService;
+import ltdjms.discord.gametoken.domain.GameTokenTransaction;
+import ltdjms.discord.gametoken.services.GameTokenService;
+import ltdjms.discord.gametoken.services.GameTokenTransactionService;
+import ltdjms.discord.product.domain.Product;
+import ltdjms.discord.shared.DomainError;
+import ltdjms.discord.shared.Result;
+
+/** Centralizes automatic product reward fulfillment across purchase and redemption flows. */
+public class ProductRewardService {
+
+  private final BalanceAdjustmentService balanceAdjustmentService;
+  private final GameTokenService gameTokenService;
+  private final CurrencyTransactionService currencyTransactionService;
+  private final GameTokenTransactionService gameTokenTransactionService;
+
+  public ProductRewardService(
+      BalanceAdjustmentService balanceAdjustmentService,
+      GameTokenService gameTokenService,
+      CurrencyTransactionService currencyTransactionService,
+      GameTokenTransactionService gameTokenTransactionService) {
+    this.balanceAdjustmentService = balanceAdjustmentService;
+    this.gameTokenService = gameTokenService;
+    this.currencyTransactionService = currencyTransactionService;
+    this.gameTokenTransactionService = gameTokenTransactionService;
+  }
+
+  public Result<RewardGrantResult, DomainError> grantReward(RewardGrantRequest request) {
+    Product product = request.product();
+    if (!product.hasReward()) {
+      return Result.err(DomainError.invalidInput("商品沒有自動獎勵"));
+    }
+    if (request.amount() <= 0) {
+      return Result.err(DomainError.invalidInput("商品獎勵金額無效"));
+    }
+
+    return switch (product.rewardType()) {
+      case CURRENCY -> grantCurrencyReward(request);
+      case TOKEN -> grantTokenReward(request);
+    };
+  }
+
+  private Result<RewardGrantResult, DomainError> grantCurrencyReward(RewardGrantRequest request) {
+    if (request.currencySource() == null) {
+      return Result.err(DomainError.unexpectedFailure("缺少貨幣獎勵交易來源", null));
+    }
+
+    var adjustResult =
+        balanceAdjustmentService.tryAdjustBalance(
+            request.guildId(), request.userId(), request.amount());
+    if (adjustResult.isErr()) {
+      return Result.err(adjustResult.getError());
+    }
+
+    currencyTransactionService.recordTransaction(
+        request.guildId(),
+        request.userId(),
+        request.amount(),
+        adjustResult.getValue().newBalance(),
+        request.currencySource(),
+        request.description());
+
+    return Result.ok(
+        new RewardGrantResult(request.amount(), adjustResult.getValue().newBalance(), null));
+  }
+
+  private Result<RewardGrantResult, DomainError> grantTokenReward(RewardGrantRequest request) {
+    if (request.tokenSource() == null) {
+      return Result.err(DomainError.unexpectedFailure("缺少代幣獎勵交易來源", null));
+    }
+
+    var adjustResult =
+        gameTokenService.tryAdjustTokens(request.guildId(), request.userId(), request.amount());
+    if (adjustResult.isErr()) {
+      return Result.err(adjustResult.getError());
+    }
+
+    gameTokenTransactionService.recordTransaction(
+        request.guildId(),
+        request.userId(),
+        request.amount(),
+        adjustResult.getValue().newTokens(),
+        request.tokenSource(),
+        request.description());
+
+    return Result.ok(
+        new RewardGrantResult(request.amount(), null, adjustResult.getValue().newTokens()));
+  }
+
+  public record RewardGrantRequest(
+      long guildId,
+      long userId,
+      Product product,
+      long amount,
+      String description,
+      CurrencyTransaction.Source currencySource,
+      GameTokenTransaction.Source tokenSource) {}
+
+  public record RewardGrantResult(long amount, Long currencyBalanceAfter, Long tokenBalanceAfter) {
+    public String formatReward(Product product) {
+      return switch (product.rewardType()) {
+        case CURRENCY -> String.format("%,d 貨幣", amount);
+        case TOKEN -> String.format("%,d 代幣", amount);
+      };
+    }
+  }
+}

--- a/src/main/java/ltdjms/discord/redemption/domain/RedemptionCodeRepository.java
+++ b/src/main/java/ltdjms/discord/redemption/domain/RedemptionCodeRepository.java
@@ -45,6 +45,16 @@ public interface RedemptionCodeRepository {
   boolean markAsRedeemedIfAvailable(long codeId, long userId, Instant redeemedAt);
 
   /**
+   * Clears redemption markers when a downstream fulfillment step fails after the atomic mark.
+   *
+   * @param codeId the redemption code ID
+   * @param userId the user ID that redeemed the code
+   * @param redeemedAt the exact redemption timestamp used when marking the code
+   * @return true if the code was restored to available state
+   */
+  boolean clearRedeemedIfMatches(long codeId, long userId, Instant redeemedAt);
+
+  /**
    * Finds a redemption code by its code string.
    *
    * @param code the code string

--- a/src/main/java/ltdjms/discord/redemption/persistence/JdbcRedemptionCodeRepository.java
+++ b/src/main/java/ltdjms/discord/redemption/persistence/JdbcRedemptionCodeRepository.java
@@ -191,6 +191,42 @@ public class JdbcRedemptionCodeRepository implements RedemptionCodeRepository {
   }
 
   @Override
+  public boolean clearRedeemedIfMatches(long codeId, long userId, Instant redeemedAt) {
+    String sql =
+        "UPDATE redemption_code SET redeemed_by = NULL, redeemed_at = NULL "
+            + "WHERE id = ? AND redeemed_by = ? AND redeemed_at = ?";
+
+    if (redeemedAt == null) {
+      return false;
+    }
+
+    try (Connection conn = dataSource.getConnection();
+        PreparedStatement stmt = conn.prepareStatement(sql)) {
+
+      stmt.setLong(1, codeId);
+      stmt.setLong(2, userId);
+      stmt.setTimestamp(3, Timestamp.from(redeemedAt));
+
+      int affected = stmt.executeUpdate();
+      if (affected == 1) {
+        LOG.warn(
+            "Cleared redeemed marker after downstream failure: id={}, userId={}", codeId, userId);
+        return true;
+      }
+
+      LOG.error(
+          "Failed to clear redeemed marker because state no longer matched: id={}, userId={}",
+          codeId,
+          userId);
+      return false;
+
+    } catch (SQLException e) {
+      LOG.error("Failed to clear redeemed marker id={}, userId={}", codeId, userId, e);
+      throw new RepositoryException("Failed to clear redeemed marker", e);
+    }
+  }
+
+  @Override
   public Optional<RedemptionCode> findByCode(String code) {
     String sql =
         "SELECT id, code, product_id, guild_id, expires_at, redeemed_by, redeemed_at, created_at,"

--- a/src/main/java/ltdjms/discord/redemption/services/RedemptionService.java
+++ b/src/main/java/ltdjms/discord/redemption/services/RedemptionService.java
@@ -9,13 +9,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import ltdjms.discord.currency.domain.CurrencyTransaction;
-import ltdjms.discord.currency.services.BalanceAdjustmentService;
-import ltdjms.discord.currency.services.CurrencyTransactionService;
 import ltdjms.discord.gametoken.domain.GameTokenTransaction;
-import ltdjms.discord.gametoken.services.GameTokenService;
-import ltdjms.discord.gametoken.services.GameTokenTransactionService;
 import ltdjms.discord.product.domain.Product;
 import ltdjms.discord.product.domain.ProductRepository;
+import ltdjms.discord.product.services.ProductRewardService;
 import ltdjms.discord.redemption.domain.ProductRedemptionTransaction;
 import ltdjms.discord.redemption.domain.RedemptionCode;
 import ltdjms.discord.redemption.domain.RedemptionCodeRepository;
@@ -36,10 +33,7 @@ public class RedemptionService {
   private final RedemptionCodeRepository codeRepository;
   private final ProductRepository productRepository;
   private final RedemptionCodeGenerator codeGenerator;
-  private final BalanceAdjustmentService balanceAdjustmentService;
-  private final GameTokenService gameTokenService;
-  private final CurrencyTransactionService currencyTransactionService;
-  private final GameTokenTransactionService gameTokenTransactionService;
+  private final ProductRewardService productRewardService;
   private final ProductRedemptionTransactionService productRedemptionTransactionService;
   private final DomainEventPublisher eventPublisher;
 
@@ -47,19 +41,13 @@ public class RedemptionService {
       RedemptionCodeRepository codeRepository,
       ProductRepository productRepository,
       RedemptionCodeGenerator codeGenerator,
-      BalanceAdjustmentService balanceAdjustmentService,
-      GameTokenService gameTokenService,
-      CurrencyTransactionService currencyTransactionService,
-      GameTokenTransactionService gameTokenTransactionService,
+      ProductRewardService productRewardService,
       ProductRedemptionTransactionService productRedemptionTransactionService,
       DomainEventPublisher eventPublisher) {
     this.codeRepository = codeRepository;
     this.productRepository = productRepository;
     this.codeGenerator = codeGenerator;
-    this.balanceAdjustmentService = balanceAdjustmentService;
-    this.gameTokenService = gameTokenService;
-    this.currencyTransactionService = currencyTransactionService;
-    this.gameTokenTransactionService = gameTokenTransactionService;
+    this.productRewardService = productRewardService;
     this.productRedemptionTransactionService = productRedemptionTransactionService;
     this.eventPublisher = eventPublisher;
   }
@@ -89,7 +77,6 @@ public class RedemptionService {
   public Result<List<RedemptionCode>, DomainError> generateCodes(
       long productId, int count, Instant expiresAt, int quantity) {
 
-    // Validate count
     if (count <= 0) {
       return Result.err(DomainError.invalidInput("生成數量必須大於 0"));
     }
@@ -97,7 +84,6 @@ public class RedemptionService {
       return Result.err(DomainError.invalidInput(String.format("單次最多生成 %d 個兌換碼", MAX_BATCH_SIZE)));
     }
 
-    // Validate quantity
     if (quantity <= 0) {
       return Result.err(DomainError.invalidInput("兌換數量必須大於 0"));
     }
@@ -105,40 +91,32 @@ public class RedemptionService {
       return Result.err(DomainError.invalidInput("單個兌換碼最多可兌換 1000 個商品"));
     }
 
-    // Validate expiration time
     if (expiresAt != null && expiresAt.isBefore(Instant.now())) {
       return Result.err(DomainError.invalidInput("過期時間必須在未來"));
     }
 
-    // Find product
     Optional<Product> productOpt = productRepository.findById(productId);
     if (productOpt.isEmpty()) {
       return Result.err(DomainError.invalidInput("找不到商品"));
     }
 
     Product product = productOpt.get();
+    List<RedemptionCode> codes = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      String code = generateUniqueCode();
+      codes.add(RedemptionCode.create(code, product.id(), product.guildId(), expiresAt, quantity));
+    }
 
     try {
-      List<RedemptionCode> codes = new ArrayList<>(count);
-      for (int i = 0; i < count; i++) {
-        String codeStr = generateUniqueCode();
-        RedemptionCode code =
-            RedemptionCode.create(codeStr, productId, product.guildId(), expiresAt, quantity);
-        codes.add(code);
-      }
-
       List<RedemptionCode> savedCodes = codeRepository.saveAll(codes);
+      eventPublisher.publish(
+          new RedemptionCodesGeneratedEvent(product.guildId(), product.id(), savedCodes.size()));
       LOG.info(
           "Generated {} redemption codes for productId={} with quantity={}",
           savedCodes.size(),
           productId,
           quantity);
-
-      // 發布事件以便面板即時刷新
-      eventPublisher.publish(
-          new RedemptionCodesGeneratedEvent(product.guildId(), productId, savedCodes.size()));
       return Result.ok(savedCodes);
-
     } catch (Exception e) {
       LOG.error("Failed to generate codes for productId={}", productId, e);
       return Result.err(DomainError.persistenceFailure("生成兌換碼失敗", e));
@@ -148,10 +126,10 @@ public class RedemptionService {
   /**
    * Redeems a code for a user.
    *
-   * @param codeStr the redemption code string
+   * @param codeStr the code string
    * @param guildId the Discord guild ID
-   * @param userId the Discord user ID
-   * @return Result containing the redemption result or an error
+   * @param userId the Discord user ID redeeming the code
+   * @return Result containing RedemptionResult on success, or an error on failure
    */
   public Result<RedemptionResult, DomainError> redeemCode(
       String codeStr, long guildId, long userId) {
@@ -160,8 +138,6 @@ public class RedemptionService {
     }
 
     codeStr = codeStr.trim().toUpperCase();
-
-    // Find code
     Optional<RedemptionCode> codeOpt = codeRepository.findByCode(codeStr);
     if (codeOpt.isEmpty()) {
       LOG.debug("Redemption code not found: {}", codeStr);
@@ -169,33 +145,23 @@ public class RedemptionService {
     }
 
     RedemptionCode code = codeOpt.get();
-
-    // Check if code belongs to this guild (don't reveal cross-guild info)
     if (!code.belongsToGuild(guildId)) {
       LOG.debug("Redemption code {} does not belong to guild {}", codeStr, guildId);
       return Result.err(DomainError.invalidInput("兌換碼無效"));
     }
-
-    // Check if code has been invalidated
     if (code.isInvalidated()) {
       LOG.debug("Redemption code {} has been invalidated", codeStr);
       return Result.err(DomainError.invalidInput("此兌換碼已失效"));
     }
-
-    // Check if already redeemed
     if (code.isRedeemed()) {
       LOG.debug("Redemption code {} already redeemed", codeStr);
       return Result.err(DomainError.invalidInput("此兌換碼已被使用"));
     }
-
-    // Check if expired
     if (code.isExpired()) {
       LOG.debug("Redemption code {} has expired", codeStr);
       return Result.err(DomainError.invalidInput("此兌換碼已過期"));
     }
 
-    // Find product
-    // If productId is null (product was deleted), treat as invalid code
     if (code.productId() == null) {
       LOG.error("Product ID is null for redemption code: codeId={}", code.id());
       return Result.err(DomainError.invalidInput("此兌換碼已失效"));
@@ -219,7 +185,6 @@ public class RedemptionService {
     }
 
     try {
-      // Mark code as redeemed
       if (code.id() == null) {
         LOG.error("Redemption code ID is null during redeem: code={}", code.getMaskedCode());
         return Result.err(DomainError.unexpectedFailure("兌換碼資料異常", null));
@@ -237,28 +202,31 @@ public class RedemptionService {
         return Result.err(DomainError.invalidInput("此兌換碼已被使用或不可用"));
       }
 
-      // Grant reward if applicable
       Long rewardedAmount = null;
       if (product.hasReward()) {
-        Result<Long, DomainError> rewardResult =
-            grantReward(guildId, userId, product, code, totalRewardAmount);
+        Result<ProductRewardService.RewardGrantResult, DomainError> rewardResult =
+            productRewardService.grantReward(
+                new ProductRewardService.RewardGrantRequest(
+                    guildId,
+                    userId,
+                    product,
+                    totalRewardAmount,
+                    String.format(
+                        "兌換碼: %s (%s) x%d", code.getMaskedCode(), product.name(), code.quantity()),
+                    CurrencyTransaction.Source.REDEMPTION_CODE,
+                    GameTokenTransaction.Source.REDEMPTION_CODE));
         if (rewardResult.isErr()) {
-          // Rollback the redemption would be complex, log and continue
-          LOG.error(
-              "Failed to grant reward for code {}: {}",
-              code.code(),
-              rewardResult.getError().message());
-        } else {
-          rewardedAmount = rewardResult.getValue();
+          return Result.err(
+              rollbackRedeemedCodeAfterRewardFailure(
+                  redeemedCode, userId, rewardResult.getError(), product.name()));
         }
+        rewardedAmount = rewardResult.getValue().amount();
       }
 
-      // Record the product redemption transaction
       ProductRedemptionTransaction transaction =
           productRedemptionTransactionService.recordTransaction(
               guildId, userId, product, redeemedCode);
 
-      // Publish event for panel updates
       eventPublisher.publish(
           new ProductRedemptionCompletedEvent(guildId, userId, transaction, Instant.now()));
 
@@ -340,54 +308,21 @@ public class RedemptionService {
         "Failed to generate unique code after " + maxAttempts + " attempts");
   }
 
-  /** Grants the reward for a product. */
-  private Result<Long, DomainError> grantReward(
-      long guildId, long userId, Product product, RedemptionCode code, Long totalRewardAmount) {
+  private DomainError rollbackRedeemedCodeAfterRewardFailure(
+      RedemptionCode redeemedCode, long userId, DomainError rewardError, String productName) {
+    LOG.error(
+        "Failed to grant reward for redeemed code {} (product={}): {}",
+        redeemedCode.getMaskedCode(),
+        productName,
+        rewardError.message());
 
-    if (!product.hasReward()) {
-      return Result.ok(null);
+    boolean reverted =
+        codeRepository.clearRedeemedIfMatches(redeemedCode.id(), userId, redeemedCode.redeemedAt());
+    if (reverted) {
+      return DomainError.unexpectedFailure("商品獎勵發放失敗，兌換已取消", rewardError.cause());
     }
 
-    if (totalRewardAmount == null) {
-      return Result.err(DomainError.invalidInput("商品獎勵金額無效"));
-    }
-
-    long totalAmount = totalRewardAmount;
-    String description =
-        String.format("兌換碼: %s (%s) x%d", code.getMaskedCode(), product.name(), code.quantity());
-
-    return switch (product.rewardType()) {
-      case CURRENCY -> {
-        var adjustResult = balanceAdjustmentService.tryAdjustBalance(guildId, userId, totalAmount);
-        if (adjustResult.isOk()) {
-          // Record the transaction with redemption source
-          currencyTransactionService.recordTransaction(
-              guildId,
-              userId,
-              totalAmount,
-              adjustResult.getValue().newBalance(),
-              CurrencyTransaction.Source.REDEMPTION_CODE,
-              description);
-          yield Result.ok(totalAmount);
-        }
-        yield Result.err(adjustResult.getError());
-      }
-      case TOKEN -> {
-        var tokenResult = gameTokenService.tryAdjustTokens(guildId, userId, totalAmount);
-        if (tokenResult.isOk()) {
-          // Record the transaction with redemption source
-          gameTokenTransactionService.recordTransaction(
-              guildId,
-              userId,
-              totalAmount,
-              tokenResult.getValue().newTokens(),
-              GameTokenTransaction.Source.REDEMPTION_CODE,
-              description);
-          yield Result.ok(totalAmount);
-        }
-        yield Result.err(tokenResult.getError());
-      }
-    };
+    return DomainError.persistenceFailure("商品獎勵發放失敗，且兌換碼回復失敗", rewardError.cause());
   }
 
   private Result<Long, DomainError> calculateTotalRewardAmount(
@@ -415,10 +350,17 @@ public class RedemptionService {
       }
 
       if (rewardedAmount != null && product.hasReward()) {
-        sb.append("\n\n已發放獎勵：").append(product.formatReward());
+        sb.append("\n\n已發放獎勵：").append(formatReward(product, rewardedAmount));
       }
 
       return sb.toString();
+    }
+
+    private String formatReward(Product product, long amount) {
+      return switch (product.rewardType()) {
+        case CURRENCY -> String.format("%,d 貨幣", amount);
+        case TOKEN -> String.format("%,d 代幣", amount);
+      };
     }
   }
 

--- a/src/main/java/ltdjms/discord/shared/di/CommandHandlerModule.java
+++ b/src/main/java/ltdjms/discord/shared/di/CommandHandlerModule.java
@@ -45,6 +45,7 @@ import ltdjms.discord.panel.services.ProductRedemptionUpdateListener;
 import ltdjms.discord.panel.services.UserPanelService;
 import ltdjms.discord.panel.services.UserPanelUpdateListener;
 import ltdjms.discord.product.domain.ProductRepository;
+import ltdjms.discord.product.services.ProductRewardService;
 import ltdjms.discord.product.services.ProductService;
 import ltdjms.discord.redemption.services.ProductRedemptionTransactionService;
 import ltdjms.discord.redemption.services.RedemptionService;
@@ -322,12 +323,14 @@ public class CommandHandlerModule {
       BalanceService balanceService,
       BalanceAdjustmentService balanceAdjustmentService,
       CurrencyTransactionService currencyTransactionService,
+      ProductRewardService productRewardService,
       ProductFulfillmentApiService productFulfillmentApiService) {
     return new ltdjms.discord.shop.services.CurrencyPurchaseService(
         productService,
         balanceService,
         balanceAdjustmentService,
         currencyTransactionService,
+        productRewardService,
         productFulfillmentApiService);
   }
 

--- a/src/main/java/ltdjms/discord/shared/di/ProductServiceModule.java
+++ b/src/main/java/ltdjms/discord/shared/di/ProductServiceModule.java
@@ -9,6 +9,7 @@ import ltdjms.discord.currency.services.CurrencyTransactionService;
 import ltdjms.discord.gametoken.services.GameTokenService;
 import ltdjms.discord.gametoken.services.GameTokenTransactionService;
 import ltdjms.discord.product.domain.ProductRepository;
+import ltdjms.discord.product.services.ProductRewardService;
 import ltdjms.discord.product.services.ProductService;
 import ltdjms.discord.redemption.domain.ProductRedemptionTransactionRepository;
 import ltdjms.discord.redemption.domain.RedemptionCodeRepository;
@@ -45,24 +46,32 @@ public class ProductServiceModule {
 
   @Provides
   @Singleton
+  public ProductRewardService provideProductRewardService(
+      BalanceAdjustmentService balanceAdjustmentService,
+      GameTokenService gameTokenService,
+      CurrencyTransactionService currencyTransactionService,
+      GameTokenTransactionService gameTokenTransactionService) {
+    return new ProductRewardService(
+        balanceAdjustmentService,
+        gameTokenService,
+        currencyTransactionService,
+        gameTokenTransactionService);
+  }
+
+  @Provides
+  @Singleton
   public RedemptionService provideRedemptionService(
       RedemptionCodeRepository codeRepository,
       ProductRepository productRepository,
       RedemptionCodeGenerator codeGenerator,
-      BalanceAdjustmentService balanceAdjustmentService,
-      GameTokenService gameTokenService,
-      CurrencyTransactionService currencyTransactionService,
-      GameTokenTransactionService gameTokenTransactionService,
+      ProductRewardService productRewardService,
       ProductRedemptionTransactionService productRedemptionTransactionService,
       DomainEventPublisher eventPublisher) {
     return new RedemptionService(
         codeRepository,
         productRepository,
         codeGenerator,
-        balanceAdjustmentService,
-        gameTokenService,
-        currencyTransactionService,
-        gameTokenTransactionService,
+        productRewardService,
         productRedemptionTransactionService,
         eventPublisher);
   }

--- a/src/main/java/ltdjms/discord/shop/services/CurrencyPurchaseService.java
+++ b/src/main/java/ltdjms/discord/shop/services/CurrencyPurchaseService.java
@@ -8,6 +8,7 @@ import ltdjms.discord.currency.services.BalanceAdjustmentService;
 import ltdjms.discord.currency.services.BalanceService;
 import ltdjms.discord.currency.services.CurrencyTransactionService;
 import ltdjms.discord.product.domain.Product;
+import ltdjms.discord.product.services.ProductRewardService;
 import ltdjms.discord.product.services.ProductService;
 import ltdjms.discord.shared.DomainError;
 import ltdjms.discord.shared.Result;
@@ -22,26 +23,21 @@ public class CurrencyPurchaseService {
   private final BalanceService balanceService;
   private final BalanceAdjustmentService balanceAdjustmentService;
   private final CurrencyTransactionService transactionService;
+  private final ProductRewardService productRewardService;
   private final ProductFulfillmentApiService productFulfillmentApiService;
 
   public CurrencyPurchaseService(
       ProductService productService,
       BalanceService balanceService,
       BalanceAdjustmentService balanceAdjustmentService,
-      CurrencyTransactionService transactionService) {
-    this(productService, balanceService, balanceAdjustmentService, transactionService, null);
-  }
-
-  public CurrencyPurchaseService(
-      ProductService productService,
-      BalanceService balanceService,
-      BalanceAdjustmentService balanceAdjustmentService,
       CurrencyTransactionService transactionService,
+      ProductRewardService productRewardService,
       ProductFulfillmentApiService productFulfillmentApiService) {
     this.productService = productService;
     this.balanceService = balanceService;
     this.balanceAdjustmentService = balanceAdjustmentService;
     this.transactionService = transactionService;
+    this.productRewardService = productRewardService;
     this.productFulfillmentApiService = productFulfillmentApiService;
   }
 
@@ -55,7 +51,6 @@ public class CurrencyPurchaseService {
    */
   public Result<PurchaseResult, DomainError> purchaseProduct(
       long guildId, long userId, long productId) {
-    // Validate product exists and has currency price
     var productOpt = productService.getProduct(productId);
     if (productOpt.isEmpty()) {
       return Result.err(DomainError.invalidInput("找不到該商品"));
@@ -71,22 +66,18 @@ public class CurrencyPurchaseService {
 
     long price = product.currencyPrice();
 
-    // Get user's current balance
     var balanceResult = balanceService.tryGetBalance(guildId, userId);
     if (balanceResult.isErr()) {
       return Result.err(balanceResult.getError());
     }
 
     long currentBalance = balanceResult.getValue().balance();
-
-    // Check if user has enough balance
     if (currentBalance < price) {
       return Result.err(
           DomainError.invalidInput(
               String.format("餘額不足。需要: %,d 貨幣，目前餘額: %,d 貨幣", price, currentBalance)));
     }
 
-    // Deduct currency
     var adjustResult = balanceAdjustmentService.tryAdjustBalance(guildId, userId, -price);
     if (adjustResult.isErr()) {
       LOG.error(
@@ -97,41 +88,40 @@ public class CurrencyPurchaseService {
       return Result.err(DomainError.persistenceFailure("扣除貨幣失敗", null));
     }
 
-    // Record transaction
-    long newBalance = adjustResult.getValue().newBalance();
+    long purchaseBalance = adjustResult.getValue().newBalance();
     transactionService.recordTransaction(
         guildId,
         userId,
         -price,
-        newBalance,
+        purchaseBalance,
         CurrencyTransaction.Source.PRODUCT_PURCHASE,
         String.format("購買商品: %s", product.name()));
 
-    // Grant product reward if applicable
+    long finalBalance = purchaseBalance;
     StringBuilder rewardMessage = new StringBuilder();
     if (product.hasReward()) {
-      // For CURRENCY reward, we need to add currency back
-      // For TOKEN reward, we would need to handle it (currently not implemented)
-      if (product.rewardType() == Product.RewardType.CURRENCY) {
-        var rewardResult =
-            balanceAdjustmentService.tryAdjustBalance(guildId, userId, product.rewardAmount());
-        if (rewardResult.isErr()) {
-          LOG.warn("Failed to grant currency reward for product: productId={}", productId);
-        } else {
-          transactionService.recordTransaction(
-              guildId,
-              userId,
-              product.rewardAmount(),
-              rewardResult.getValue().newBalance(),
-              CurrencyTransaction.Source.REDEMPTION_CODE,
-              String.format("商品獎勵: %s", product.name()));
-          rewardMessage.append(String.format("\n\n獲得獎勵: %,d 貨幣", product.rewardAmount()));
-        }
-      } else if (product.rewardType() == Product.RewardType.TOKEN) {
-        rewardMessage.append(String.format("\n\n獲得獎勵: %,d 代幣", product.rewardAmount()));
-        // Note: Token handling would need to be implemented separately
+      Result<ProductRewardService.RewardGrantResult, DomainError> rewardResult =
+          productRewardService.grantReward(
+              new ProductRewardService.RewardGrantRequest(
+                  guildId,
+                  userId,
+                  product,
+                  product.rewardAmount(),
+                  String.format("商品獎勵: %s", product.name()),
+                  CurrencyTransaction.Source.PRODUCT_REWARD,
+                  ltdjms.discord.gametoken.domain.GameTokenTransaction.Source.PRODUCT_REWARD));
+      if (rewardResult.isErr()) {
+        return refundPurchaseAfterRewardFailure(
+            guildId, userId, product, price, rewardResult.getError(), productId);
       }
+
+      ProductRewardService.RewardGrantResult grantedReward = rewardResult.getValue();
+      if (grantedReward.currencyBalanceAfter() != null) {
+        finalBalance = grantedReward.currencyBalanceAfter();
+      }
+      rewardMessage.append("\n\n獲得獎勵: ").append(grantedReward.formatReward(product));
     }
+
     rewardMessage.append(tryNotifyBackendFulfillment(guildId, userId, product));
 
     LOG.info(
@@ -142,9 +132,46 @@ public class CurrencyPurchaseService {
         price);
 
     PurchaseResult result =
-        new PurchaseResult(product, currentBalance, newBalance, price, rewardMessage.toString());
-
+        new PurchaseResult(product, currentBalance, finalBalance, price, rewardMessage.toString());
     return Result.ok(result);
+  }
+
+  private Result<PurchaseResult, DomainError> refundPurchaseAfterRewardFailure(
+      long guildId,
+      long userId,
+      Product product,
+      long price,
+      DomainError rewardError,
+      long productId) {
+    LOG.error(
+        "Failed to grant reward for purchased product: guildId={}, userId={}, productId={},"
+            + " reason={}",
+        guildId,
+        userId,
+        productId,
+        rewardError.message());
+
+    var refundResult = balanceAdjustmentService.tryAdjustBalance(guildId, userId, price);
+    if (refundResult.isErr()) {
+      LOG.error(
+          "Failed to refund purchase after reward failure: guildId={}, userId={}, productId={},"
+              + " reason={}",
+          guildId,
+          userId,
+          productId,
+          refundResult.getError().message());
+      return Result.err(DomainError.persistenceFailure("商品獎勵發放失敗，且自動退款失敗", null));
+    }
+
+    transactionService.recordTransaction(
+        guildId,
+        userId,
+        price,
+        refundResult.getValue().newBalance(),
+        CurrencyTransaction.Source.PRODUCT_PURCHASE_REFUND,
+        String.format("商品購買退款: %s", product.name()));
+
+    return Result.err(DomainError.unexpectedFailure("商品獎勵發放失敗，已自動退款", rewardError.cause()));
   }
 
   private String tryNotifyBackendFulfillment(long guildId, long userId, Product product) {

--- a/src/test/java/ltdjms/discord/product/services/ProductRewardServiceTest.java
+++ b/src/test/java/ltdjms/discord/product/services/ProductRewardServiceTest.java
@@ -1,0 +1,136 @@
+package ltdjms.discord.product.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import ltdjms.discord.currency.domain.CurrencyTransaction;
+import ltdjms.discord.currency.services.BalanceAdjustmentService;
+import ltdjms.discord.currency.services.CurrencyTransactionService;
+import ltdjms.discord.gametoken.domain.GameTokenTransaction;
+import ltdjms.discord.gametoken.services.GameTokenService;
+import ltdjms.discord.gametoken.services.GameTokenTransactionService;
+import ltdjms.discord.product.domain.Product;
+import ltdjms.discord.shared.Result;
+
+@ExtendWith(MockitoExtension.class)
+class ProductRewardServiceTest {
+
+  private static final long TEST_GUILD_ID = 123456789012345678L;
+  private static final long TEST_USER_ID = 987654321098765432L;
+
+  @Mock private BalanceAdjustmentService balanceAdjustmentService;
+  @Mock private GameTokenService gameTokenService;
+  @Mock private CurrencyTransactionService currencyTransactionService;
+  @Mock private GameTokenTransactionService gameTokenTransactionService;
+
+  private ProductRewardService productRewardService;
+
+  @BeforeEach
+  void setUp() {
+    productRewardService =
+        new ProductRewardService(
+            balanceAdjustmentService,
+            gameTokenService,
+            currencyTransactionService,
+            gameTokenTransactionService);
+  }
+
+  @Test
+  @DisplayName("should grant currency reward and record transaction")
+  void shouldGrantCurrencyRewardAndRecordTransaction() {
+    Product product =
+        new Product(
+            1L,
+            TEST_GUILD_ID,
+            "禮包",
+            null,
+            Product.RewardType.CURRENCY,
+            100L,
+            null,
+            Instant.now(),
+            Instant.now());
+    when(balanceAdjustmentService.tryAdjustBalance(TEST_GUILD_ID, TEST_USER_ID, 250L))
+        .thenReturn(
+            Result.ok(
+                new BalanceAdjustmentService.BalanceAdjustmentResult(
+                    TEST_GUILD_ID, TEST_USER_ID, 500L, 750L, 250L, "Coins", "🪙")));
+
+    Result<ProductRewardService.RewardGrantResult, ltdjms.discord.shared.DomainError> result =
+        productRewardService.grantReward(
+            new ProductRewardService.RewardGrantRequest(
+                TEST_GUILD_ID,
+                TEST_USER_ID,
+                product,
+                250L,
+                "商品獎勵: 禮包",
+                CurrencyTransaction.Source.PRODUCT_REWARD,
+                GameTokenTransaction.Source.PRODUCT_REWARD));
+
+    assertThat(result.isOk()).isTrue();
+    assertThat(result.getValue().amount()).isEqualTo(250L);
+    assertThat(result.getValue().currencyBalanceAfter()).isEqualTo(750L);
+    verify(currencyTransactionService)
+        .recordTransaction(
+            TEST_GUILD_ID,
+            TEST_USER_ID,
+            250L,
+            750L,
+            CurrencyTransaction.Source.PRODUCT_REWARD,
+            "商品獎勵: 禮包");
+    verifyNoInteractions(gameTokenService, gameTokenTransactionService);
+  }
+
+  @Test
+  @DisplayName("should grant token reward and record transaction")
+  void shouldGrantTokenRewardAndRecordTransaction() {
+    Product product =
+        new Product(
+            1L,
+            TEST_GUILD_ID,
+            "代幣包",
+            null,
+            Product.RewardType.TOKEN,
+            50L,
+            null,
+            Instant.now(),
+            Instant.now());
+    when(gameTokenService.tryAdjustTokens(TEST_GUILD_ID, TEST_USER_ID, 75L))
+        .thenReturn(
+            Result.ok(
+                new GameTokenService.TokenAdjustmentResult(
+                    TEST_GUILD_ID, TEST_USER_ID, 0L, 75L, 75L)));
+
+    Result<ProductRewardService.RewardGrantResult, ltdjms.discord.shared.DomainError> result =
+        productRewardService.grantReward(
+            new ProductRewardService.RewardGrantRequest(
+                TEST_GUILD_ID,
+                TEST_USER_ID,
+                product,
+                75L,
+                "商品獎勵: 代幣包",
+                CurrencyTransaction.Source.PRODUCT_REWARD,
+                GameTokenTransaction.Source.PRODUCT_REWARD));
+
+    assertThat(result.isOk()).isTrue();
+    assertThat(result.getValue().amount()).isEqualTo(75L);
+    assertThat(result.getValue().tokenBalanceAfter()).isEqualTo(75L);
+    verify(gameTokenTransactionService)
+        .recordTransaction(
+            TEST_GUILD_ID,
+            TEST_USER_ID,
+            75L,
+            75L,
+            GameTokenTransaction.Source.PRODUCT_REWARD,
+            "商品獎勵: 代幣包");
+    verifyNoInteractions(balanceAdjustmentService, currencyTransactionService);
+  }
+}

--- a/src/test/java/ltdjms/discord/redemption/persistence/JdbcRedemptionCodeRepositoryTest.java
+++ b/src/test/java/ltdjms/discord/redemption/persistence/JdbcRedemptionCodeRepositoryTest.java
@@ -131,6 +131,51 @@ class JdbcRedemptionCodeRepositoryTest {
   }
 
   @Nested
+  @DisplayName("clearRedeemedIfMatches")
+  class ClearRedeemedIfMatchesTests {
+
+    @Test
+    @DisplayName("當更新一筆資料時應返回 true")
+    void shouldReturnTrueWhenOneRowUpdated() throws SQLException {
+      PreparedStatement stmt = mock(PreparedStatement.class);
+      Instant redeemedAt = Instant.parse("2026-02-01T00:00:00Z");
+
+      when(connection.prepareStatement(anyString())).thenReturn(stmt);
+      when(stmt.executeUpdate()).thenReturn(1);
+
+      boolean result = repository.clearRedeemedIfMatches(TEST_CODE_ID, TEST_USER_ID, redeemedAt);
+
+      assertThat(result).isTrue();
+      verify(stmt).setLong(1, TEST_CODE_ID);
+      verify(stmt).setLong(2, TEST_USER_ID);
+      verify(stmt).setTimestamp(3, Timestamp.from(redeemedAt));
+    }
+
+    @Test
+    @DisplayName("當 redeemedAt 為 null 時應直接返回 false")
+    void shouldReturnFalseWhenRedeemedAtIsNull() {
+      boolean result = repository.clearRedeemedIfMatches(TEST_CODE_ID, TEST_USER_ID, null);
+
+      assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("SQL 應同時比對 redeemed_by 與 redeemed_at")
+    void shouldMatchRedeemerAndTimestampInSql() throws SQLException {
+      PreparedStatement stmt = mock(PreparedStatement.class);
+      ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+
+      when(connection.prepareStatement(sqlCaptor.capture())).thenReturn(stmt);
+      when(stmt.executeUpdate()).thenReturn(1);
+
+      repository.clearRedeemedIfMatches(
+          TEST_CODE_ID, TEST_USER_ID, Instant.parse("2026-02-01T00:00:00Z"));
+
+      assertThat(sqlCaptor.getValue()).contains("redeemed_by = ?").contains("redeemed_at = ?");
+    }
+  }
+
+  @Nested
   @DisplayName("invalidated code queries")
   class InvalidatedCodeQueryTests {
 

--- a/src/test/java/ltdjms/discord/redemption/services/RedemptionServiceEventTest.java
+++ b/src/test/java/ltdjms/discord/redemption/services/RedemptionServiceEventTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 
 import ltdjms.discord.product.domain.Product;
 import ltdjms.discord.product.domain.ProductRepository;
+import ltdjms.discord.product.services.ProductRewardService;
 import ltdjms.discord.redemption.domain.RedemptionCode;
 import ltdjms.discord.redemption.domain.RedemptionCodeRepository;
 import ltdjms.discord.shared.DomainError;
@@ -44,10 +45,7 @@ class RedemptionServiceEventTest {
             codeRepository,
             productRepository,
             codeGenerator,
-            mock(ltdjms.discord.currency.services.BalanceAdjustmentService.class),
-            mock(ltdjms.discord.gametoken.services.GameTokenService.class),
-            mock(ltdjms.discord.currency.services.CurrencyTransactionService.class),
-            mock(ltdjms.discord.gametoken.services.GameTokenTransactionService.class),
+            mock(ProductRewardService.class),
             mock(ProductRedemptionTransactionService.class),
             eventPublisher);
   }

--- a/src/test/java/ltdjms/discord/redemption/services/RedemptionServiceTest.java
+++ b/src/test/java/ltdjms/discord/redemption/services/RedemptionServiceTest.java
@@ -17,12 +17,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import ltdjms.discord.currency.services.BalanceAdjustmentService;
-import ltdjms.discord.currency.services.CurrencyTransactionService;
-import ltdjms.discord.gametoken.services.GameTokenService;
-import ltdjms.discord.gametoken.services.GameTokenTransactionService;
 import ltdjms.discord.product.domain.Product;
 import ltdjms.discord.product.domain.ProductRepository;
+import ltdjms.discord.product.services.ProductRewardService;
 import ltdjms.discord.redemption.domain.ProductRedemptionTransaction;
 import ltdjms.discord.redemption.domain.RedemptionCode;
 import ltdjms.discord.redemption.domain.RedemptionCodeRepository;
@@ -41,10 +38,7 @@ class RedemptionServiceTest {
   @Mock private RedemptionCodeRepository codeRepository;
   @Mock private ProductRepository productRepository;
   @Mock private RedemptionCodeGenerator codeGenerator;
-  @Mock private BalanceAdjustmentService balanceAdjustmentService;
-  @Mock private GameTokenService gameTokenService;
-  @Mock private CurrencyTransactionService currencyTransactionService;
-  @Mock private GameTokenTransactionService gameTokenTransactionService;
+  @Mock private ProductRewardService productRewardService;
   @Mock private ProductRedemptionTransactionService productRedemptionTransactionService;
   @Mock private DomainEventPublisher eventPublisher;
 
@@ -57,10 +51,7 @@ class RedemptionServiceTest {
             codeRepository,
             productRepository,
             codeGenerator,
-            balanceAdjustmentService,
-            gameTokenService,
-            currencyTransactionService,
-            gameTokenTransactionService,
+            productRewardService,
             productRedemptionTransactionService,
             eventPublisher);
   }
@@ -501,11 +492,8 @@ class RedemptionServiceTest {
       when(codeRepository.findByCode("ABCD1234EFGH5678")).thenReturn(Optional.of(code));
       when(productRepository.findById(TEST_PRODUCT_ID)).thenReturn(Optional.of(product));
       when(codeRepository.markAsRedeemedIfAvailable(anyLong(), anyLong(), any())).thenReturn(true);
-      when(balanceAdjustmentService.tryAdjustBalance(TEST_GUILD_ID, TEST_USER_ID, 1000L))
-          .thenReturn(
-              Result.ok(
-                  new BalanceAdjustmentService.BalanceAdjustmentResult(
-                      TEST_GUILD_ID, TEST_USER_ID, 0L, 1000L, 1000L, "Coins", "🪙")));
+      when(productRewardService.grantReward(any()))
+          .thenReturn(Result.ok(new ProductRewardService.RewardGrantResult(1000L, 1000L, null)));
       when(productRedemptionTransactionService.recordTransaction(
               eq(TEST_GUILD_ID), eq(TEST_USER_ID), eq(product), any()))
           .thenReturn(transaction);
@@ -517,7 +505,7 @@ class RedemptionServiceTest {
       // Then
       assertThat(result.isOk()).isTrue();
       assertThat(result.getValue().rewardedAmount()).isEqualTo(1000L);
-      verify(balanceAdjustmentService).tryAdjustBalance(TEST_GUILD_ID, TEST_USER_ID, 1000L);
+      verify(productRewardService).grantReward(any());
       verify(productRedemptionTransactionService)
           .recordTransaction(eq(TEST_GUILD_ID), eq(TEST_USER_ID), eq(product), any());
       verify(eventPublisher).publish(any());
@@ -556,11 +544,8 @@ class RedemptionServiceTest {
       when(codeRepository.findByCode("ABC")).thenReturn(Optional.of(code));
       when(productRepository.findById(TEST_PRODUCT_ID)).thenReturn(Optional.of(product));
       when(codeRepository.markAsRedeemedIfAvailable(anyLong(), anyLong(), any())).thenReturn(true);
-      when(balanceAdjustmentService.tryAdjustBalance(TEST_GUILD_ID, TEST_USER_ID, 1000L))
-          .thenReturn(
-              Result.ok(
-                  new BalanceAdjustmentService.BalanceAdjustmentResult(
-                      TEST_GUILD_ID, TEST_USER_ID, 0L, 1000L, 1000L, "Coins", "🪙")));
+      when(productRewardService.grantReward(any()))
+          .thenReturn(Result.ok(new ProductRewardService.RewardGrantResult(1000L, 1000L, null)));
       when(productRedemptionTransactionService.recordTransaction(
               eq(TEST_GUILD_ID), eq(TEST_USER_ID), eq(product), any()))
           .thenReturn(transaction);
@@ -572,7 +557,7 @@ class RedemptionServiceTest {
       // Then
       assertThat(result.isOk()).isTrue();
       assertThat(result.getValue().rewardedAmount()).isEqualTo(1000L);
-      verify(balanceAdjustmentService).tryAdjustBalance(TEST_GUILD_ID, TEST_USER_ID, 1000L);
+      verify(productRewardService).grantReward(any());
     }
 
     @Test
@@ -617,11 +602,8 @@ class RedemptionServiceTest {
       when(codeRepository.findByCode("ABCD1234EFGH5678")).thenReturn(Optional.of(code));
       when(productRepository.findById(TEST_PRODUCT_ID)).thenReturn(Optional.of(product));
       when(codeRepository.markAsRedeemedIfAvailable(anyLong(), anyLong(), any())).thenReturn(true);
-      when(gameTokenService.tryAdjustTokens(TEST_GUILD_ID, TEST_USER_ID, 50L))
-          .thenReturn(
-              Result.ok(
-                  new GameTokenService.TokenAdjustmentResult(
-                      TEST_GUILD_ID, TEST_USER_ID, 0L, 50L, 50L)));
+      when(productRewardService.grantReward(any()))
+          .thenReturn(Result.ok(new ProductRewardService.RewardGrantResult(50L, null, 50L)));
       when(productRedemptionTransactionService.recordTransaction(
               eq(TEST_GUILD_ID), eq(TEST_USER_ID), eq(product), any()))
           .thenReturn(transaction);
@@ -633,7 +615,7 @@ class RedemptionServiceTest {
       // Then
       assertThat(result.isOk()).isTrue();
       assertThat(result.getValue().rewardedAmount()).isEqualTo(50L);
-      verify(gameTokenService).tryAdjustTokens(TEST_GUILD_ID, TEST_USER_ID, 50L);
+      verify(productRewardService).grantReward(any());
       verify(productRedemptionTransactionService)
           .recordTransaction(eq(TEST_GUILD_ID), eq(TEST_USER_ID), eq(product), any());
       verify(eventPublisher).publish(any());
@@ -699,6 +681,108 @@ class RedemptionServiceTest {
   class RedeemCodeFailureTests {
 
     @Test
+    @DisplayName("should rollback redeemed code when reward fulfillment fails")
+    void shouldRollbackRedeemedCodeWhenRewardFulfillmentFails() {
+      // Given
+      Instant now = Instant.now();
+      Product product =
+          new Product(
+              Long.valueOf(TEST_PRODUCT_ID),
+              TEST_GUILD_ID,
+              "禮包",
+              null,
+              Product.RewardType.CURRENCY,
+              1000L,
+              null,
+              now,
+              now);
+      RedemptionCode code =
+          new RedemptionCode(
+              1L,
+              "ABCD1234EFGH5678",
+              TEST_PRODUCT_ID,
+              TEST_GUILD_ID,
+              null,
+              null,
+              null,
+              now,
+              null,
+              1);
+
+      when(codeRepository.findByCode("ABCD1234EFGH5678")).thenReturn(Optional.of(code));
+      when(productRepository.findById(TEST_PRODUCT_ID)).thenReturn(Optional.of(product));
+      when(codeRepository.markAsRedeemedIfAvailable(eq(1L), eq(TEST_USER_ID), any()))
+          .thenReturn(true);
+      when(productRewardService.grantReward(any()))
+          .thenReturn(Result.err(DomainError.unexpectedFailure("Reward failed", null)));
+      when(codeRepository.clearRedeemedIfMatches(eq(1L), eq(TEST_USER_ID), any())).thenReturn(true);
+
+      // When
+      Result<RedemptionService.RedemptionResult, DomainError> result =
+          redemptionService.redeemCode("ABCD1234EFGH5678", TEST_GUILD_ID, TEST_USER_ID);
+
+      // Then
+      assertThat(result.isErr()).isTrue();
+      assertThat(result.getError().message()).contains("兌換已取消");
+      verify(codeRepository).clearRedeemedIfMatches(eq(1L), eq(TEST_USER_ID), any());
+      verify(productRedemptionTransactionService, never())
+          .recordTransaction(anyLong(), anyLong(), any(), any());
+      verify(eventPublisher, never()).publish(any());
+    }
+
+    @Test
+    @DisplayName("should surface persistence failure when reward rollback also fails")
+    void shouldSurfacePersistenceFailureWhenRewardRollbackAlsoFails() {
+      // Given
+      Instant now = Instant.now();
+      Product product =
+          new Product(
+              Long.valueOf(TEST_PRODUCT_ID),
+              TEST_GUILD_ID,
+              "禮包",
+              null,
+              Product.RewardType.CURRENCY,
+              1000L,
+              null,
+              now,
+              now);
+      RedemptionCode code =
+          new RedemptionCode(
+              1L,
+              "ABCD1234EFGH5678",
+              TEST_PRODUCT_ID,
+              TEST_GUILD_ID,
+              null,
+              null,
+              null,
+              now,
+              null,
+              1);
+
+      when(codeRepository.findByCode("ABCD1234EFGH5678")).thenReturn(Optional.of(code));
+      when(productRepository.findById(TEST_PRODUCT_ID)).thenReturn(Optional.of(product));
+      when(codeRepository.markAsRedeemedIfAvailable(eq(1L), eq(TEST_USER_ID), any()))
+          .thenReturn(true);
+      when(productRewardService.grantReward(any()))
+          .thenReturn(Result.err(DomainError.unexpectedFailure("Reward failed", null)));
+      when(codeRepository.clearRedeemedIfMatches(eq(1L), eq(TEST_USER_ID), any()))
+          .thenReturn(false);
+
+      // When
+      Result<RedemptionService.RedemptionResult, DomainError> result =
+          redemptionService.redeemCode("ABCD1234EFGH5678", TEST_GUILD_ID, TEST_USER_ID);
+
+      // Then
+      assertThat(result.isErr()).isTrue();
+      assertThat(result.getError().category()).isEqualTo(DomainError.Category.PERSISTENCE_FAILURE);
+      assertThat(result.getError().message()).contains("回復失敗");
+      verify(codeRepository).clearRedeemedIfMatches(eq(1L), eq(TEST_USER_ID), any());
+      verify(productRedemptionTransactionService, never())
+          .recordTransaction(anyLong(), anyLong(), any(), any());
+      verify(eventPublisher, never()).publish(any());
+    }
+
+    @Test
     @DisplayName("should reject overflowed reward before marking code redeemed")
     void shouldRejectOverflowedRewardBeforeMarkingCodeRedeemed() {
       // Given
@@ -738,7 +822,7 @@ class RedemptionServiceTest {
       assertThat(result.isErr()).isTrue();
       assertThat(result.getError().message()).contains("獎勵");
       verify(codeRepository, never()).markAsRedeemedIfAvailable(anyLong(), anyLong(), any());
-      verify(balanceAdjustmentService, never()).tryAdjustBalance(anyLong(), anyLong(), anyLong());
+      verify(productRewardService, never()).grantReward(any());
     }
 
     @Test
@@ -918,7 +1002,7 @@ class RedemptionServiceTest {
       assertThat(result.isErr()).isTrue();
       assertThat(result.getError().message()).contains("獎勵");
       verify(codeRepository, never()).markAsRedeemedIfAvailable(anyLong(), anyLong(), any());
-      verify(balanceAdjustmentService, never()).tryAdjustBalance(anyLong(), anyLong(), anyLong());
+      verify(productRewardService, never()).grantReward(any());
       verify(productRedemptionTransactionService, never())
           .recordTransaction(anyLong(), anyLong(), any(), any());
     }

--- a/src/test/java/ltdjms/discord/shop/services/CurrencyPurchaseServiceTest.java
+++ b/src/test/java/ltdjms/discord/shop/services/CurrencyPurchaseServiceTest.java
@@ -20,6 +20,7 @@ import ltdjms.discord.currency.services.BalanceAdjustmentService;
 import ltdjms.discord.currency.services.BalanceService;
 import ltdjms.discord.currency.services.CurrencyTransactionService;
 import ltdjms.discord.product.domain.Product;
+import ltdjms.discord.product.services.ProductRewardService;
 import ltdjms.discord.product.services.ProductService;
 import ltdjms.discord.shared.DomainError;
 import ltdjms.discord.shared.Result;
@@ -43,6 +44,8 @@ class CurrencyPurchaseServiceTest {
 
   @Mock private CurrencyTransactionService transactionService;
 
+  @Mock private ProductRewardService productRewardService;
+
   @Mock private ProductFulfillmentApiService productFulfillmentApiService;
 
   private CurrencyPurchaseService purchaseService;
@@ -51,7 +54,12 @@ class CurrencyPurchaseServiceTest {
   void setUp() {
     purchaseService =
         new CurrencyPurchaseService(
-            productService, balanceService, balanceAdjustmentService, transactionService);
+            productService,
+            balanceService,
+            balanceAdjustmentService,
+            transactionService,
+            productRewardService,
+            null);
   }
 
   @Nested
@@ -144,7 +152,6 @@ class CurrencyPurchaseServiceTest {
       when(balanceAdjustmentService.tryAdjustBalance(
               TEST_GUILD_ID, TEST_USER_ID, -TEST_CURRENCY_PRICE))
           .thenReturn(Result.ok(adjustmentResult));
-
       // When
       Result<CurrencyPurchaseService.PurchaseResult, DomainError> result =
           purchaseService.purchaseProduct(TEST_GUILD_ID, TEST_USER_ID, TEST_PRODUCT_ID);
@@ -319,12 +326,10 @@ class CurrencyPurchaseServiceTest {
               TEST_GUILD_ID, TEST_USER_ID, -TEST_CURRENCY_PRICE))
           .thenReturn(Result.ok(deductResult));
 
-      var rewardResult =
-          new BalanceAdjustmentService.BalanceAdjustmentResult(
-              TEST_GUILD_ID, TEST_USER_ID, 500L, 600L, TEST_REWARD_AMOUNT, "Coins", "💰");
-      when(balanceAdjustmentService.tryAdjustBalance(
-              TEST_GUILD_ID, TEST_USER_ID, TEST_REWARD_AMOUNT))
-          .thenReturn(Result.ok(rewardResult));
+      when(productRewardService.grantReward(any()))
+          .thenReturn(
+              Result.ok(
+                  new ProductRewardService.RewardGrantResult(TEST_REWARD_AMOUNT, 600L, null)));
 
       // When
       Result<CurrencyPurchaseService.PurchaseResult, DomainError> result =
@@ -333,11 +338,13 @@ class CurrencyPurchaseServiceTest {
       // Then
       assertThat(result.isOk()).isTrue();
       assertThat(result.getValue().rewardMessage()).contains("獲得獎勵: 100 貨幣");
+      assertThat(result.getValue().newBalance()).isEqualTo(600L);
+      verify(productRewardService).grantReward(any());
     }
 
     @Test
-    @DisplayName("should handle TOKEN reward without balance adjustment")
-    void shouldHandleTokenRewardWithoutBalanceAdjustment() {
+    @DisplayName("should fulfill TOKEN reward via centralized reward service")
+    void shouldFulfillTokenRewardViaCentralizedRewardService() {
       // Given
       Product product =
           new Product(
@@ -362,6 +369,10 @@ class CurrencyPurchaseServiceTest {
       when(balanceAdjustmentService.tryAdjustBalance(
               TEST_GUILD_ID, TEST_USER_ID, -TEST_CURRENCY_PRICE))
           .thenReturn(Result.ok(adjustmentResult));
+      when(productRewardService.grantReward(any()))
+          .thenReturn(
+              Result.ok(
+                  new ProductRewardService.RewardGrantResult(TEST_REWARD_AMOUNT, null, 100L)));
 
       // When
       Result<CurrencyPurchaseService.PurchaseResult, DomainError> result =
@@ -370,13 +381,57 @@ class CurrencyPurchaseServiceTest {
       // Then
       assertThat(result.isOk()).isTrue();
       assertThat(result.getValue().rewardMessage()).contains("獲得獎勵: 100 代幣");
+      verify(productRewardService).grantReward(any());
       verify(balanceAdjustmentService, never())
           .tryAdjustBalance(eq(TEST_GUILD_ID), eq(TEST_USER_ID), eq(TEST_REWARD_AMOUNT));
     }
 
     @Test
-    @DisplayName("should continue purchase when reward granting fails")
-    void shouldContinuePurchaseWhenRewardGrantingFails() {
+    @DisplayName("should surface persistence failure when refund also fails")
+    void shouldSurfacePersistenceFailureWhenRefundAlsoFails() {
+      // Given
+      Product product =
+          new Product(
+              TEST_PRODUCT_ID,
+              TEST_GUILD_ID,
+              "Test Product",
+              "Description",
+              Product.RewardType.CURRENCY,
+              TEST_REWARD_AMOUNT,
+              TEST_CURRENCY_PRICE,
+              Instant.now(),
+              Instant.now());
+      when(productService.getProduct(TEST_PRODUCT_ID)).thenReturn(Optional.of(product));
+
+      BalanceView balance = new BalanceView(TEST_GUILD_ID, TEST_USER_ID, 1000L, "Coins", "💰");
+      when(balanceService.tryGetBalance(TEST_GUILD_ID, TEST_USER_ID))
+          .thenReturn(Result.ok(balance));
+
+      var deductResult =
+          new BalanceAdjustmentService.BalanceAdjustmentResult(
+              TEST_GUILD_ID, TEST_USER_ID, 1000L, 500L, -TEST_CURRENCY_PRICE, "Coins", "💰");
+      when(balanceAdjustmentService.tryAdjustBalance(
+              TEST_GUILD_ID, TEST_USER_ID, -TEST_CURRENCY_PRICE))
+          .thenReturn(Result.ok(deductResult));
+      when(productRewardService.grantReward(any()))
+          .thenReturn(Result.err(DomainError.unexpectedFailure("Reward failed", null)));
+      when(balanceAdjustmentService.tryAdjustBalance(
+              TEST_GUILD_ID, TEST_USER_ID, TEST_CURRENCY_PRICE))
+          .thenReturn(Result.err(DomainError.persistenceFailure("refund failed", null)));
+
+      // When
+      Result<CurrencyPurchaseService.PurchaseResult, DomainError> result =
+          purchaseService.purchaseProduct(TEST_GUILD_ID, TEST_USER_ID, TEST_PRODUCT_ID);
+
+      // Then
+      assertThat(result.isErr()).isTrue();
+      assertThat(result.getError().category()).isEqualTo(DomainError.Category.PERSISTENCE_FAILURE);
+      assertThat(result.getError().message()).contains("自動退款失敗");
+    }
+
+    @Test
+    @DisplayName("should refund purchase when reward granting fails")
+    void shouldRefundPurchaseWhenRewardGrantingFails() {
       // Given
       Product product =
           new Product(
@@ -402,17 +457,32 @@ class CurrencyPurchaseServiceTest {
               TEST_GUILD_ID, TEST_USER_ID, -TEST_CURRENCY_PRICE))
           .thenReturn(Result.ok(deductResult));
 
-      when(balanceAdjustmentService.tryAdjustBalance(
-              TEST_GUILD_ID, TEST_USER_ID, TEST_REWARD_AMOUNT))
+      when(productRewardService.grantReward(any()))
           .thenReturn(Result.err(DomainError.unexpectedFailure("Reward failed", null)));
+      var refundResult =
+          new BalanceAdjustmentService.BalanceAdjustmentResult(
+              TEST_GUILD_ID, TEST_USER_ID, 500L, 1000L, TEST_CURRENCY_PRICE, "Coins", "💰");
+      when(balanceAdjustmentService.tryAdjustBalance(
+              TEST_GUILD_ID, TEST_USER_ID, TEST_CURRENCY_PRICE))
+          .thenReturn(Result.ok(refundResult));
 
       // When
       Result<CurrencyPurchaseService.PurchaseResult, DomainError> result =
           purchaseService.purchaseProduct(TEST_GUILD_ID, TEST_USER_ID, TEST_PRODUCT_ID);
 
       // Then
-      assertThat(result.isOk()).isTrue();
-      assertThat(result.getValue().rewardMessage()).isEmpty();
+      assertThat(result.isErr()).isTrue();
+      assertThat(result.getError().message()).contains("已自動退款");
+      verify(balanceAdjustmentService)
+          .tryAdjustBalance(TEST_GUILD_ID, TEST_USER_ID, TEST_CURRENCY_PRICE);
+      verify(transactionService)
+          .recordTransaction(
+              TEST_GUILD_ID,
+              TEST_USER_ID,
+              TEST_CURRENCY_PRICE,
+              1000L,
+              ltdjms.discord.currency.domain.CurrencyTransaction.Source.PRODUCT_PURCHASE_REFUND,
+              "商品購買退款: Test Product");
     }
   }
 
@@ -429,6 +499,7 @@ class CurrencyPurchaseServiceTest {
               balanceService,
               balanceAdjustmentService,
               transactionService,
+              productRewardService,
               productFulfillmentApiService);
 
       Product product =
@@ -458,6 +529,10 @@ class CurrencyPurchaseServiceTest {
       when(balanceAdjustmentService.tryAdjustBalance(
               TEST_GUILD_ID, TEST_USER_ID, -TEST_CURRENCY_PRICE))
           .thenReturn(Result.ok(deductResult));
+      when(productRewardService.grantReward(any()))
+          .thenReturn(
+              Result.ok(
+                  new ProductRewardService.RewardGrantResult(TEST_REWARD_AMOUNT, null, 100L)));
 
       when(productFulfillmentApiService.notifyFulfillment(any())).thenReturn(Result.okVoid());
 
@@ -477,6 +552,7 @@ class CurrencyPurchaseServiceTest {
               balanceService,
               balanceAdjustmentService,
               transactionService,
+              productRewardService,
               productFulfillmentApiService);
 
       Product product =
@@ -506,6 +582,10 @@ class CurrencyPurchaseServiceTest {
       when(balanceAdjustmentService.tryAdjustBalance(
               TEST_GUILD_ID, TEST_USER_ID, -TEST_CURRENCY_PRICE))
           .thenReturn(Result.ok(deductResult));
+      when(productRewardService.grantReward(any()))
+          .thenReturn(
+              Result.ok(
+                  new ProductRewardService.RewardGrantResult(TEST_REWARD_AMOUNT, null, 100L)));
 
       when(productFulfillmentApiService.notifyFulfillment(any()))
           .thenReturn(Result.err(DomainError.unexpectedFailure("backend error", null)));


### PR DESCRIPTION
## Related Issues / Motivation
- Closes #49
- Product reward fulfillment had diverged between shop purchases and redemption codes. Token rewards from purchases only showed a message, currency rewards reported the wrong post-purchase balance, and redemption failures could still consume the code.

## Engineering Decisions and Rationale
- Added `ProductRewardService` to centralize reward adjustments and transaction recording so purchase and redemption flows share the same fulfillment semantics.
- Updated `CurrencyPurchaseService` to use the shared reward workflow, surface the final balance after currency rewards, and automatically refund the purchase when reward fulfillment fails.
- Updated `RedemptionService` to compensate failed reward fulfillment by clearing the redeemed marker before returning an error, so codes are not silently consumed.
- Added guarded repository support for clearing a redeemed code only when the stored redeemer and timestamp still match, which keeps the rollback narrow and concurrency-safe.

## Test Results and Commands
- ✅ `mvn -Dtest=ProductRewardServiceTest,CurrencyPurchaseServiceTest,RedemptionServiceTest,RedemptionServiceEventTest,JdbcRedemptionCodeRepositoryTest test`
- ✅ `mvn -Ptype-safety -DskipTests test-compile`

### Test Cases
- Purchase with token reward -> reward service is invoked, reward text is shown, and no duplicate balance adjustment is attempted.
- Purchase reward failure -> purchase is refunded; refund failure is surfaced as a persistence error.
- Redemption reward failure -> redeemed code is restored when possible; rollback failure is surfaced explicitly.
