### PR TITLE
fix: guard AIChatResponse null content edge case

### DIFF
--- a/src/main/java/ltdjms/discord/aichat/domain/AIChatResponse.java
+++ b/src/main/java/ltdjms/discord/aichat/domain/AIChatResponse.java
@@ -73,6 +73,7 @@ public record AIChatResponse(
     if (first.message() == null) {
       return "";
     }
-    return first.message().content();
+    String content = first.message().content();
+    return content == null ? "" : content;
   }
 }

--- a/src/test/java/ltdjms/discord/aichat/unit/AIChatResponseTest.java
+++ b/src/test/java/ltdjms/discord/aichat/unit/AIChatResponseTest.java
@@ -181,4 +181,25 @@ class AIChatResponseTest {
     // 驗證
     assertThat(content).isEmpty();
   }
+
+  @Test
+  void testGetContent_withNullMessageContent_shouldReturnEmptyString() {
+    // 前置
+    AIChatResponse response =
+        new AIChatResponse(
+            "chatcmpl-123",
+            "chat.completion",
+            1677652288L,
+            "gpt-3.5-turbo",
+            List.of(
+                new AIChatResponse.Choice(
+                    0, new AIChatResponse.Choice.AIMessage("assistant", null, null), "stop")),
+            new AIChatResponse.Usage(10, 20, 30));
+
+    // 執行
+    String content = response.getContent();
+
+    // 驗證
+    assertThat(content).isEmpty();
+  }
 }


### PR DESCRIPTION
## Summary
- harden `AIChatResponse#getContent()` to return empty string when first choice message content is null
- add regression test for null `message.content` payload from upstream AI API responses

## Edge case covered
- upstream chat completion payload returns a first choice with `message` present but `content: null`

## Tests
- `mvn -q -Dtest=AIChatResponseTest test` (fails before fix, passes after)
- `mvn -q -Dtest=AIChatResponseTest,AIChatDomainTest test`

## Risk
- low; only affects fallback behavior for malformed/partial AI payloads
