### PR TITLE
Harden SSRF checks for IPv6 ULA targets

### DIFF
--- a/src/main/java/ltdjms/discord/product/services/ProductService.java
+++ b/src/main/java/ltdjms/discord/product/services/ProductService.java
@@ -1,5 +1,6 @@
 package ltdjms.discord.product.services;
 
+import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.URI;
 import java.util.List;
@@ -415,10 +416,19 @@ public class ProductService {
           || address.isLoopbackAddress()
           || address.isLinkLocalAddress()
           || address.isSiteLocalAddress()
-          || address.isMulticastAddress();
+          || address.isMulticastAddress()
+          || isIpv6UniqueLocalAddress(address);
     } catch (Exception e) {
       return true;
     }
+  }
+
+  private boolean isIpv6UniqueLocalAddress(InetAddress address) {
+    if (!(address instanceof Inet6Address inet6)) {
+      return false;
+    }
+    byte[] raw = inet6.getAddress();
+    return raw.length > 0 && (raw[0] & (byte) 0xFE) == (byte) 0xFC;
   }
 
   private boolean looksLikeIpLiteral(String host) {

--- a/src/main/java/ltdjms/discord/shop/services/ProductFulfillmentApiService.java
+++ b/src/main/java/ltdjms/discord/shop/services/ProductFulfillmentApiService.java
@@ -1,5 +1,6 @@
 package ltdjms.discord.shop.services;
 
+import java.net.Inet6Address;
 import java.net.URI;
 import java.net.UnknownHostException;
 import java.net.http.HttpClient;
@@ -258,7 +259,16 @@ public class ProductFulfillmentApiService {
         || address.isLoopbackAddress()
         || address.isLinkLocalAddress()
         || address.isSiteLocalAddress()
-        || address.isMulticastAddress();
+        || address.isMulticastAddress()
+        || isIpv6UniqueLocalAddress(address);
+  }
+
+  private boolean isIpv6UniqueLocalAddress(java.net.InetAddress address) {
+    if (!(address instanceof Inet6Address inet6)) {
+      return false;
+    }
+    byte[] raw = inet6.getAddress();
+    return raw.length > 0 && (raw[0] & (byte) 0xFE) == (byte) 0xFC;
   }
 
   @FunctionalInterface

--- a/src/test/java/ltdjms/discord/product/services/ProductServiceTest.java
+++ b/src/test/java/ltdjms/discord/product/services/ProductServiceTest.java
@@ -300,6 +300,29 @@ class ProductServiceTest {
     }
 
     @Test
+    @DisplayName("should reject IPv6 ULA backend API target")
+    void shouldRejectIpv6UniqueLocalBackendApiUrl() {
+      when(productRepository.existsByGuildIdAndName(TEST_GUILD_ID, "Unsafe IPv6 Backend"))
+          .thenReturn(false);
+
+      Result<Product, DomainError> result =
+          productService.createProduct(
+              TEST_GUILD_ID,
+              "Unsafe IPv6 Backend",
+              "desc",
+              null,
+              null,
+              300L,
+              null,
+              "http://[fc00::1]/internal",
+              false,
+              null);
+
+      assertThat(result.isErr()).isTrue();
+      assertThat(result.getError().message()).contains("localhost 或內網位址");
+    }
+
+    @Test
     @DisplayName("should handle persistence failure on create")
     void shouldHandlePersistenceFailureOnCreate() {
       // Given

--- a/src/test/java/ltdjms/discord/shop/services/ProductFulfillmentApiServiceTest.java
+++ b/src/test/java/ltdjms/discord/shop/services/ProductFulfillmentApiServiceTest.java
@@ -295,4 +295,51 @@ class ProductFulfillmentApiServiceTest {
     assertThat(result.getError().message()).contains("localhost 或內網位址");
     verify(httpClient, never()).send(any(), anyStringBodyHandler());
   }
+
+  @Test
+  @DisplayName("應拒絕解析到 IPv6 ULA 私網位址，避免 SSRF")
+  void shouldRejectDomainResolvingToIpv6UniqueLocalAddress() throws Exception {
+    ProductFulfillmentApiService securedService =
+        new ProductFulfillmentApiService(
+            escortOptionPricingService,
+            httpClient,
+            new ObjectMapper(),
+            Clock.fixed(Instant.parse("2026-03-04T00:00:00Z"), ZoneOffset.UTC),
+            host -> {
+              if ("attacker-v6.example".equals(host)) {
+                return new InetAddress[] {InetAddress.getByName("fc00::1")};
+              }
+              throw new java.net.UnknownHostException(host);
+            });
+
+    Product product =
+        new Product(
+            1L,
+            GUILD_ID,
+            "Unsafe IPv6 Backend Domain",
+            null,
+            Product.RewardType.CURRENCY,
+            100L,
+            200L,
+            null,
+            "https://attacker-v6.example/internal",
+            false,
+            null,
+            Instant.now(),
+            Instant.now());
+
+    Result<ltdjms.discord.shared.Unit, DomainError> result =
+        securedService.notifyFulfillment(
+            new ProductFulfillmentApiService.FulfillmentRequest(
+                GUILD_ID,
+                USER_ID,
+                product,
+                ProductFulfillmentApiService.PurchaseSource.CURRENCY_PURCHASE,
+                null,
+                null));
+
+    assertThat(result.isErr()).isTrue();
+    assertThat(result.getError().message()).contains("localhost 或內網位址");
+    verify(httpClient, never()).send(any(), anyStringBodyHandler());
+  }
 }


### PR DESCRIPTION
## Related issues or motivation
- Security automation found a bypass in SSRF target validation: IPv6 Unique Local Addresses (fc00::/7) were not blocked by the current address checks.
- This allowed internal/private IPv6 destinations to pass validation in both product URL normalization and runtime fulfillment URL resolution.

## Engineering decisions and rationale
- Added explicit IPv6 ULA detection (fc00::/7) in both guard paths:
  - `ProductService.isDisallowedBackendHost(...)`
  - `ProductFulfillmentApiService.isDisallowedAddress(...)`
- Kept the fix minimal and local to existing trust-boundary validators to avoid refactoring unrelated logic.
- Added regression tests proving the previous exploit path and validating the fix:
  - Product backend URL creation path rejects `http://[fc00::1]/...`
  - Runtime DNS resolution path rejects domains resolving to `fc00::1`

## Test results
- `mvn -q -Dtest=ProductFulfillmentApiServiceTest,ProductServiceTest test`
  - Pass
